### PR TITLE
Add Spatial Canvas prototype with backend persistence and subgraph API

### DIFF
--- a/.planning/research/spatial-rdf-canvas-integration-plan.md
+++ b/.planning/research/spatial-rdf-canvas-integration-plan.md
@@ -1,0 +1,231 @@
+# SemPKM Spatial RDF Canvas — Project-Specific Implementation Plan
+
+## Why this plan is different from the generic PRD plan
+The PRD/implementation draft assumes a greenfield React app with canvas-specific APIs. SemPKM today is:
+- FastAPI + Jinja templates + htmx shell (no frontend build pipeline in main app).
+- Cytoscape-based graph view already present under `/browser/views/graph/*`.
+- Server-rendered workspace tabs managed by Dockview, where each view is loaded via htmx into an editor panel.
+
+This plan integrates the canvas incrementally into that architecture so we can ship value without destabilizing the existing graph/browser flows.
+
+---
+
+## 1) Current-codebase fit analysis (concrete integration points)
+
+### Frontend shell and navigation
+- Workspace view tabs are opened by `frontend/static/js/workspace.js` and route through `/browser/views/{renderer}/{spec}`.
+- Graph view currently renders via template + Cytoscape boot code (`frontend/static/js/graph.js`).
+- Base scripts are CDN/static JS loaded from `backend/app/templates/base.html`.
+
+### Backend services we can leverage
+- View loading and graph data access already live in `backend/app/views/router.py` + `backend/app/views/service.py`.
+- User-scoped settings persistence exists (`/browser/settings/*`) backed by `user_settings` rows via `SettingsService`.
+- Event-sourced writes already exist via command dispatch (`/api/commands`), which can later support “agent writes” provenance hooks.
+
+### Implication
+We should ship canvas as a new **view renderer type** in the existing workspace flow first, not a separate SPA.
+
+---
+
+## 2) Proposed architecture for SemPKM
+
+## 2.1 Rendering model
+- Keep HTMX shell as-is.
+- Add a **React Flow island** inside a new template (`browser/canvas_view.html`) mounted to a single DOM root.
+- Keep inspector/details on the server side initially (existing right pane + htmx partials), avoiding duplicate state systems.
+
+## 2.2 Frontend packaging decision
+Because the app currently has no JS build step, we should choose one of these two tracks before coding:
+
+### Track A (recommended): checked-in bundled asset
+- Build a small Vite bundle in a `frontend/canvas-ui/` workspace.
+- Commit built artifacts to `frontend/static/js/canvas/`.
+- Load with normal `<script src="/js/canvas/main.js">` from template.
+- Pros: modern React Flow DX, predictable runtime, no CDN module complexity.
+- Cons: introduces build workflow for contributors.
+
+### Track B: CDN ESM only
+- Attempt no-build React/ReactDOM/ReactFlow via ESM CDNs.
+- Pros: no local build tooling.
+- Cons: brittle imports/version pinning/caching/debuggability; higher long-term risk.
+
+Recommendation: **Track A** for maintainability.
+
+## 2.3 Data and persistence model
+- Internal saved canvas format = React Flow `toObject()` + SemPKM metadata in `node.data` / `edge.data`.
+- Store per-user canvases using `user_settings` first (keyed under `canvas.{canvas_id}`) to avoid introducing a new DB table in MVP.
+- If size/scale becomes an issue, migrate to dedicated SQL table (`canvas_documents`) in Beta.
+
+## 2.4 RDF graph source
+- Reuse existing graph service primitives where possible.
+- Add focused canvas endpoints for predictable payload shape:
+  - `GET /api/canvas/{id}`
+  - `PUT /api/canvas/{id}`
+  - `GET /api/canvas/subgraph?root_uri=&depth=&predicates=`
+- Keep query scoping rules consistent with existing current-graph semantics.
+
+---
+
+## 3) Phased implementation plan (SemPKM-specific)
+
+## Phase C0 — Decision gate + thin vertical slice (2–3 days)
+**Goal:** de-risk packaging and mount strategy.
+
+Tasks:
+1. Finalize Track A vs B packaging.
+2. Add a minimal `/browser/views/canvas/{spec_iri}` route and template shell.
+3. Mount a hard-coded React Flow graph in workspace tab.
+4. Ensure no regression to existing table/card/graph renderers.
+
+Deliverable: canvas tab opens in Dockview and supports pan/zoom with hardcoded nodes.
+
+---
+
+## Phase C1 — Backend canvas document API (3–4 days)
+**Goal:** save/restore canvas state using existing auth + user setting infrastructure.
+
+Tasks:
+1. Add `backend/app/canvas/router.py` with read/write endpoints.
+2. Add lightweight schemas for flow document validation.
+3. Implement storage adapter backed by `SettingsService` key namespace:
+   - `canvas.{id}.document`
+   - `canvas.{id}.meta`
+4. Add optimistic concurrency field (`updated_at` or revision token) to avoid accidental overwrite.
+
+Deliverable: exact restore of nodes/edges/viewport after refresh.
+
+---
+
+## Phase C2 — Integrate RDF subgraph loading (4–5 days)
+**Goal:** load real resource nodes + RDF edges into canvas.
+
+Tasks:
+1. Add subgraph endpoint reusing ViewSpecService/SPARQL helper patterns.
+2. Transform response to React Flow node/edge contracts with stable IDs.
+3. Add “add node by URI” action in canvas panel UI.
+4. Add edge metadata payload for right-pane inspection (predicate IRI, labels).
+
+Deliverable: users can place resources and see RDF edges among present nodes.
+
+---
+
+## Phase C3 — Markdown expansion + link-anchor edges (5–7 days)
+**Goal:** make nodes semantically rich and spatially anchored.
+
+Tasks:
+1. Reuse markdown rendering conventions from existing `markdown-render.js` behavior where possible (sanitization/link policies).
+2. Implement node expand/collapse with markdown preview.
+3. Parse rendered links and compute dynamic anchor handles.
+4. Trigger `updateNodeInternals(nodeId)` whenever anchors change.
+5. Create markdown-link edges to existing target nodes; prompt to add missing targets.
+
+Deliverable: expanded nodes show anchor dots and edges originate from link-aligned handles.
+
+---
+
+## Phase C4 — Agent write streaming MVP (4–6 days)
+**Goal:** live node updates while file/resource content changes.
+
+Tasks:
+1. Add SSE endpoint under existing API conventions (or bridge to existing event stream if available).
+2. Implement `useAgentStream` client hook with reconnect/backoff.
+3. Update node markdown incrementally (v1 full-text replace acceptable).
+4. Recompute anchors after each update.
+5. Badge state: writing / updated / error.
+
+Deliverable: demo where node content visibly updates in real time without page refresh.
+
+---
+
+## Phase C5 — JSON Canvas import/export + perf guardrails (4–5 days)
+**Goal:** interoperability and stability at moderate graph size.
+
+Tasks:
+1. Export React Flow document to JSON Canvas 1.0 (best effort).
+2. Import JSON Canvas into node/edge layout.
+3. Add zoom-threshold behavior to hide markdown/anchors when zoomed out.
+4. Limit neighbor-expansion batch size and add predicate filters.
+
+Deliverable: 50 nodes / 200 edges remains smooth on modern laptop baseline.
+
+---
+
+## 4) Concrete file-level change map
+
+### New backend modules
+- `backend/app/canvas/router.py`
+- `backend/app/canvas/schemas.py`
+- `backend/app/canvas/service.py`
+- `backend/app/canvas/__init__.py`
+
+### Backend integration touchpoints
+- `backend/app/main.py` (router registration)
+- `backend/app/templates/browser/canvas_view.html` (canvas host)
+- `backend/app/views/router.py` (add/route renderer type `canvas` if needed)
+
+### Frontend additions (Track A)
+- `frontend/canvas-ui/*` (source + build config)
+- `frontend/static/js/canvas/main.js` (built artifact)
+- `frontend/static/css/canvas.css`
+- `frontend/static/js/workspace.js` (open/load canvas view type)
+
+---
+
+## 5) Testing and rollout strategy
+
+## Automated
+- Backend pytest:
+  - canvas API CRUD + auth checks.
+  - subgraph endpoint contract tests.
+  - JSON canvas adapter unit tests.
+- Frontend tests (if added in canvas-ui):
+  - transform functions, anchor math, import/export.
+- E2E Playwright:
+  - open canvas tab, add node, save, reload, restore.
+  - expand markdown node and verify anchor markers.
+
+## Manual acceptance gates
+1. No regression in current table/card/graph views.
+2. Canvas doc persists per user session/account as expected.
+3. Anchor edges remain attached after node drag, zoom changes, and markdown updates.
+4. SSE stream survives brief network drop and resumes cleanly.
+
+## Release strategy
+- Ship behind feature flag (`settings.experimental.canvas_enabled`) for one milestone.
+- Enable for **all authenticated users** in the initial rollout (no admin-only restriction).
+
+---
+
+## 6) Risks and SemPKM-specific mitigations
+- **Build-pipeline drift risk:** committing built assets can drift from source.
+  - Mitigation: add CI check that rebuild diff is clean.
+- **Anchor measurement instability inside Dockview/htmx lifecycle:** render timing races.
+  - Mitigation: schedule anchor measure on `requestAnimationFrame` + `ResizeObserver` + node expansion events.
+- **Payload bloat in user_settings:** very large canvases may exceed practical limits.
+  - Mitigation: enforce size cap + migrate to dedicated table at Beta.
+- **Semantic mismatch between markdown links and RDF URIs:** existing content may mix wiki links/files/IRIs.
+  - Mitigation: define canonical link resolver before C3 (see locked decisions below).
+
+---
+
+## 7) Decisions (locked)
+
+The following implementation decisions are now **approved** and should be treated as baseline constraints for execution:
+
+1. **Packaging:** **Track A** (Vite-built, checked-in bundle).
+2. **Storage scope (MVP):** **Per-user private** canvases.
+3. **Canonical ID:** **RDF URI canonical**; file path retained as metadata.
+4. **Link dialect (MVP):** **Standard Markdown links only** (`[text](...)`).
+5. **Auto-triples from markdown links:** **No** in MVP (visual edge only).
+6. **Rollout policy:** **All authenticated users** (feature enabled broadly, no admin-only preview).
+
+### Execution implications of locked decisions
+
+- Frontend implementation should proceed with `frontend/canvas-ui/` source + committed built output under `frontend/static/js/canvas/` (Track A).
+- Canvas persistence should use the existing user-scoped settings path for MVP (`canvas.{id}.*` in `user_settings`), deferring shared/team canvases to a later phase.
+- Node identity handling, subgraph lookup, and edge wiring should treat URI as the sole canonical key to avoid duplication conflicts.
+- Markdown anchor parsing can scope to standard link tokens in MVP; wiki-link parsing is explicitly out-of-scope for initial delivery.
+- Markdown link edges remain UI/visual semantics only in MVP; RDF graph mutation stays opt-in and future-scoped.
+- Feature flagging, if used, should target all authenticated users rather than admin-only gating.
+
+These decisions unblock conversion into execution-ready phase plans (`C0-01`, `C1-01`, etc.) matching the existing `.planning/phases/*` workflow.

--- a/backend/app/browser/router.py
+++ b/backend/app/browser/router.py
@@ -153,6 +153,19 @@ async def docs_guide_viewer(
     })
 
 
+@router.get("/canvas")
+async def canvas_page(
+    request: Request,
+    user: User = Depends(get_current_user),
+):
+    """Render the Spatial Canvas workspace tab (M0 prototype)."""
+    templates = request.app.state.templates
+    return templates.TemplateResponse(request, "browser/canvas_page.html", {
+        "request": request,
+        "user": user,
+    })
+
+
 @router.get("/settings/data")
 async def settings_data(
     user: User = Depends(get_current_user),

--- a/backend/app/canvas/__init__.py
+++ b/backend/app/canvas/__init__.py
@@ -1,0 +1,1 @@
+"""Spatial canvas API package (C1 persistence endpoints)."""

--- a/backend/app/canvas/router.py
+++ b/backend/app/canvas/router.py
@@ -1,0 +1,123 @@
+"""Canvas API endpoints for save/load (C1)."""
+
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user
+from app.auth.models import User
+from app.canvas.schemas import CanvasPutBody, CanvasResponse
+from app.canvas.service import CanvasService
+from app.db.session import get_db_session
+from app.dependencies import get_view_spec_service
+from app.views.service import ViewSpecService
+
+router = APIRouter(prefix="/api/canvas", tags=["canvas"])
+
+
+def _is_valid_iri(value: str) -> bool:
+    """Validate a basic IRI shape before SPARQL interpolation."""
+    if not value:
+        return False
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return False
+    if any(ch in value for ch in '<>"\n\r\t '):
+        return False
+    if parsed.scheme in ("http", "https"):
+        return bool(parsed.netloc)
+    if parsed.scheme == "urn":
+        return bool(parsed.path)
+    return False
+
+
+def get_canvas_service() -> CanvasService:
+    """FastAPI dependency returning a CanvasService instance."""
+    return CanvasService()
+
+
+@router.get("/{canvas_id}", response_model=CanvasResponse)
+async def get_canvas_document(
+    canvas_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    service: CanvasService = Depends(get_canvas_service),
+):
+    """Load a user-scoped canvas document by canvas_id."""
+    document, updated_at = await service.load_document(user.id, canvas_id, db)
+    return CanvasResponse(canvas_id=canvas_id, document=document, updated_at=updated_at)
+
+
+@router.put("/{canvas_id}", response_model=CanvasResponse)
+async def put_canvas_document(
+    canvas_id: str,
+    body: CanvasPutBody,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    service: CanvasService = Depends(get_canvas_service),
+):
+    """Save a user-scoped canvas document by canvas_id."""
+    updated_at = await service.save_document(user.id, canvas_id, body.document, db)
+    return CanvasResponse(canvas_id=canvas_id, document=body.document, updated_at=updated_at)
+
+
+@router.get("/subgraph")
+async def get_canvas_subgraph(
+    root_uri: str = Query(..., description="Root resource URI"),
+    depth: int = Query(1, ge=1, le=2),
+    user: User = Depends(get_current_user),
+    view_spec_service: ViewSpecService = Depends(get_view_spec_service),
+):
+    """Return a neighborhood subgraph for canvas expansion."""
+    if not _is_valid_iri(root_uri):
+        raise HTTPException(status_code=400, detail="Invalid root_uri")
+
+    frontier = {root_uri}
+    expanded: set[str] = set()
+    seen_nodes: dict[str, dict] = {}
+    seen_edges: dict[tuple[str, str, str], str] = {}
+
+    for _ in range(depth):
+        if not frontier:
+            break
+
+        next_frontier: set[str] = set()
+        for iri in frontier:
+            if iri in expanded:
+                continue
+            expanded.add(iri)
+
+            result = await view_spec_service.expand_neighbors(iri)
+            for node in result.get("nodes", []):
+                node_id = node.get("id")
+                if node_id and node_id not in seen_nodes:
+                    seen_nodes[node_id] = node
+                if node_id and node_id not in expanded:
+                    next_frontier.add(node_id)
+            for edge in result.get("edges", []):
+                source = edge.get("source", "")
+                target = edge.get("target", "")
+                predicate = edge.get("predicate", "")
+                key = (source, target, predicate)
+                if source and target and key not in seen_edges:
+                    seen_edges[key] = edge.get("predicate_label") or predicate
+
+        frontier = next_frontier
+
+    edges_out = [
+        {
+            "source": s,
+            "target": t,
+            "predicate": p,
+            "predicate_label": label,
+        }
+        for ((s, t, p), label) in seen_edges.items()
+    ]
+
+    return {
+        "root_uri": root_uri,
+        "depth": depth,
+        "nodes": list(seen_nodes.values()),
+        "edges": edges_out,
+    }

--- a/backend/app/canvas/schemas.py
+++ b/backend/app/canvas/schemas.py
@@ -1,0 +1,19 @@
+"""Pydantic schemas for Spatial Canvas persistence endpoints."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CanvasPutBody(BaseModel):
+    """Request body for saving a canvas document."""
+
+    document: dict[str, Any] = Field(default_factory=dict)
+
+
+class CanvasResponse(BaseModel):
+    """Response payload for canvas load/save endpoints."""
+
+    canvas_id: str
+    document: dict[str, Any]
+    updated_at: str | None = None

--- a/backend/app/canvas/service.py
+++ b/backend/app/canvas/service.py
@@ -1,0 +1,108 @@
+"""Canvas persistence service backed by user_settings entries."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.models import UserSetting
+
+
+class CanvasService:
+    """Persist and load user-scoped canvas documents via user_settings."""
+
+    @staticmethod
+    def _doc_key(canvas_id: str) -> str:
+        return f"canvas.{canvas_id}.document"
+
+    @staticmethod
+    def _meta_key(canvas_id: str) -> str:
+        return f"canvas.{canvas_id}.meta"
+
+    async def load_document(
+        self,
+        user_id: uuid.UUID,
+        canvas_id: str,
+        db: AsyncSession,
+    ) -> tuple[dict, str | None]:
+        """Load a canvas document and updated timestamp for a user."""
+        doc_row = await db.execute(
+            select(UserSetting).where(
+                UserSetting.user_id == user_id,
+                UserSetting.key == self._doc_key(canvas_id),
+            )
+        )
+        doc_setting = doc_row.scalar_one_or_none()
+
+        meta_row = await db.execute(
+            select(UserSetting).where(
+                UserSetting.user_id == user_id,
+                UserSetting.key == self._meta_key(canvas_id),
+            )
+        )
+        meta_setting = meta_row.scalar_one_or_none()
+
+        document: dict = {
+            "nodes": [],
+            "edges": [],
+            "viewport": {"x": 0, "y": 0, "zoom": 1},
+        }
+        updated_at: str | None = None
+
+        if doc_setting and doc_setting.value:
+            try:
+                parsed = json.loads(doc_setting.value)
+                if isinstance(parsed, dict):
+                    document = parsed
+            except Exception:
+                pass
+
+        if meta_setting and meta_setting.value:
+            try:
+                parsed_meta = json.loads(meta_setting.value)
+                if isinstance(parsed_meta, dict):
+                    updated_at = parsed_meta.get("updated_at")
+            except Exception:
+                pass
+
+        return document, updated_at
+
+    async def save_document(
+        self,
+        user_id: uuid.UUID,
+        canvas_id: str,
+        document: dict,
+        db: AsyncSession,
+    ) -> str:
+        """Upsert canvas document + metadata and return updated_at ISO timestamp."""
+        updated_at = datetime.now(tz=timezone.utc).isoformat()
+        doc_value = json.dumps(document)
+        meta_value = json.dumps({"updated_at": updated_at})
+
+        await self._upsert_setting(db, user_id, self._doc_key(canvas_id), doc_value)
+        await self._upsert_setting(db, user_id, self._meta_key(canvas_id), meta_value)
+        await db.commit()
+        return updated_at
+
+    async def _upsert_setting(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        key: str,
+        value: str,
+    ) -> None:
+        row = await db.execute(
+            select(UserSetting).where(
+                UserSetting.user_id == user_id,
+                UserSetting.key == key,
+            )
+        )
+        existing = row.scalar_one_or_none()
+        if existing:
+            existing.value = value
+        else:
+            db.add(UserSetting(user_id=user_id, key=key, value=value))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from jinja2_fragments.fastapi import Jinja2Blocks
 from app.admin.router import router as admin_router
 from app.auth.router import router as auth_router
 from app.browser.router import router as browser_router
+from app.canvas.router import router as canvas_router
 from app.views.router import router as views_router
 from app.debug.router import router as debug_router
 from app.auth.service import AuthService
@@ -378,6 +379,7 @@ app.include_router(validation_router)
 app.include_router(admin_router)
 app.include_router(views_router)
 app.include_router(browser_router)
+app.include_router(canvas_router)
 app.include_router(debug_router)
 app.include_router(shell_router)
 

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -101,6 +101,7 @@
     <script src="/js/named-layouts.js"></script>
     <script src="/js/workspace.js"></script>
     <script src="/js/graph.js"></script>
+    <script src="/js/canvas.js"></script>
     <script src="/js/column-prefs.js"></script>
     {% block scripts %}{% endblock %}
 </body>

--- a/backend/app/templates/browser/canvas_page.html
+++ b/backend/app/templates/browser/canvas_page.html
@@ -1,0 +1,32 @@
+<div class="canvas-page" data-testid="spatial-canvas-page">
+  <div class="canvas-page-toolbar">
+    <div class="canvas-page-title">
+      <strong>Spatial Canvas (M0)</strong>
+      <span>Pan, zoom, and drag sample resource nodes.</span>
+    </div>
+    <div class="canvas-page-actions">
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.zoomOut()">-</button>
+      <span id="spatial-canvas-zoom" class="canvas-page-zoom">100%</span>
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.zoomIn()">+</button>
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.resetView()">Reset view</button>
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.load()">Load</button>
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.save()">Save</button>
+      <button class="btn-secondary" type="button" onclick="if(window.SemPKMCanvas) window.SemPKMCanvas.loadNeighbors()">Expand Neighbors</button>
+    </div>
+  </div>
+
+  <div id="spatial-canvas-root" class="spatial-canvas-root" data-canvas-id="default">
+    <div class="spatial-canvas-viewport">
+      <div class="spatial-canvas-layer"></div>
+    </div>
+  </div>
+  <div id="spatial-canvas-status" class="canvas-page-status" aria-live="polite"></div>
+
+  <script>
+    (function () {
+      if (window.SemPKMCanvas && typeof window.SemPKMCanvas.mount === 'function') {
+        window.SemPKMCanvas.mount();
+      }
+    })();
+  </script>
+</div>

--- a/backend/app/templates/browser/views_explorer.html
+++ b/backend/app/templates/browser/views_explorer.html
@@ -4,6 +4,12 @@
      groups: list of dicts with type_iri, type_label, specs (ViewSpec list)
 #}
 
+<a class="tree-leaf view-leaf" href="#"
+   onclick="openCanvasTab(); return false;">
+    <span class="tree-leaf-icon">&#9635;</span>
+    <span class="tree-leaf-label">Spatial Canvas (Beta)</span>
+</a>
+
 {% if groups %}
 {% for group in groups %}
 <div class="tree-node view-group-node expanded" data-type-iri="{{ group.type_iri }}">

--- a/frontend/static/css/workspace.css
+++ b/frontend/static/css/workspace.css
@@ -2677,3 +2677,221 @@ details.form-group[open] > .form-group-summary::before {
     opacity: 1;
     transform: translateX(-50%) translateY(0);
 }
+
+/* Spatial canvas prototype (M0) */
+.canvas-page {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  min-height: 420px;
+}
+
+.canvas-page-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.canvas-page-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.canvas-page-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.canvas-page-zoom {
+  min-width: 42px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.spatial-canvas-root,
+.spatial-canvas-viewport {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.spatial-canvas-root {
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-surface);
+}
+
+.spatial-canvas-viewport {
+  cursor: grab;
+  background-image:
+    linear-gradient(to right, rgba(127, 127, 127, 0.12) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(127, 127, 127, 0.12) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+.spatial-canvas-viewport.is-panning {
+  cursor: grabbing;
+}
+
+.spatial-canvas-layer {
+  position: absolute;
+  inset: 0;
+  transform-origin: top left;
+}
+
+.spatial-node {
+  position: absolute;
+  width: 260px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-elevated, #f8fafc);
+  box-shadow: var(--shadow-md);
+  padding: 10px;
+  user-select: none;
+}
+
+.spatial-node.dragging {
+  opacity: 0.88;
+}
+
+.spatial-node-header {
+  font-weight: 600;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.spatial-node-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spatial-node-toggle {
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-text-muted);
+  border-radius: 6px;
+  font-size: 10px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.spatial-node.is-collapsed .spatial-node-markdown {
+  display: none;
+}
+
+.spatial-node-uri {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  word-break: break-all;
+}
+
+
+.spatial-edges {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.spatial-edge-line {
+  stroke: var(--color-accent, #2563eb);
+  stroke-width: 2;
+  marker-end: url(#spatial-edge-arrow);
+  opacity: 0.85;
+}
+
+.spatial-edge-arrow-path {
+  fill: var(--color-accent, #2563eb);
+}
+
+.spatial-edge-label {
+  fill: var(--color-text-muted, #475569);
+  font-size: 11px;
+  font-family: var(--font-sans, sans-serif);
+  text-anchor: middle;
+}
+
+[data-theme="dark"] .spatial-node {
+  background: var(--color-bg-elevated, #1e293b);
+  border-color: var(--color-border-default, #334155);
+}
+
+
+.spatial-node-markdown {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border-default);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--color-text-default);
+}
+
+.spatial-node-markdown h1,
+.spatial-node-markdown h2,
+.spatial-node-markdown h3,
+.spatial-node-markdown h4,
+.spatial-node-markdown h5,
+.spatial-node-markdown h6 {
+  margin: 0 0 6px 0;
+  font-size: 13px;
+}
+
+.spatial-node-markdown p,
+.spatial-node-markdown ul,
+.spatial-node-markdown ol {
+  margin: 0 0 6px 0;
+}
+
+.spatial-node-markdown ul,
+.spatial-node-markdown ol {
+  padding-left: 18px;
+}
+
+.spatial-node-markdown code {
+  font-family: var(--font-mono);
+  background: var(--color-bg-subtle, rgba(127,127,127,0.12));
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
+.spatial-node-markdown a {
+  color: var(--color-accent, #2563eb);
+  text-decoration: underline;
+}
+
+
+.canvas-page-status {
+  min-height: 18px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.canvas-page-status.error {
+  color: var(--color-danger, #dc2626);
+}
+
+
+.spatial-edge-line-markdown {
+  stroke-dasharray: 4 3;
+  opacity: 0.75;
+}
+
+.spatial-anchor-dot {
+  fill: var(--color-accent, #2563eb);
+  opacity: 0.9;
+}

--- a/frontend/static/js/canvas.js
+++ b/frontend/static/js/canvas.js
@@ -1,0 +1,580 @@
+/**
+ * SemPKM Spatial Canvas (C0 slice)
+ *
+ * Lightweight canvas prototype with pan/zoom and draggable resource cards.
+ * This is intentionally framework-free as a bridge until the React Flow
+ * island (Track A) lands.
+ */
+(function () {
+  'use strict';
+
+  var state = {
+    mounted: false,
+    scale: 1,
+    minScale: 0.3,
+    maxScale: 2.5,
+    translateX: 0,
+    translateY: 0,
+    isPanning: false,
+    panStartX: 0,
+    panStartY: 0,
+    nodeDragId: null,
+    nodeDragOffsetX: 0,
+    nodeDragOffsetY: 0,
+    nodes: [
+      {
+        id: 'urn:sempkm:model:basic-pkm:seed-note-arch',
+        title: 'Architecture Decision',
+        uri: 'urn:sempkm:model:basic-pkm:seed-note-arch',
+        x: 160,
+        y: 120,
+        markdown: '## Architecture Decision\n\n- Adopt **Track A** for packaging.\n- Add `React Flow` island in workspace.\n\n[Open project node](urn:sempkm:model:basic-pkm:seed-project-kernel)',
+        collapsed: false,
+      },
+      {
+        id: 'urn:sempkm:model:basic-pkm:seed-project-kernel',
+        title: 'Project: Spatial Canvas Beta',
+        uri: 'urn:sempkm:model:basic-pkm:seed-project-kernel',
+        x: 540,
+        y: 300,
+        markdown: '### Spatial Canvas Beta\n\nThis project tracks:\n1. Canvas persistence\n2. RDF subgraph loading\n3. Markdown anchors\n\nSee [Architecture Decision](urn:sempkm:model:basic-pkm:seed-note-arch).',
+        collapsed: false,
+      }
+    ],
+    edges: [
+      { id: 'link-1', source: 'urn:sempkm:model:basic-pkm:seed-note-arch', target: 'urn:sempkm:model:basic-pkm:seed-project-kernel', label: 'related to' }
+    ],
+    canvasId: 'default'
+  };
+
+  function mountCanvas() {
+    var root = document.getElementById('spatial-canvas-root');
+    if (!root) return;
+    if (state.mounted) return;
+
+    var viewport = root.querySelector('.spatial-canvas-viewport');
+    var layer = root.querySelector('.spatial-canvas-layer');
+    if (!viewport || !layer) return;
+
+    state.viewport = viewport;
+    state.layer = layer;
+    state.canvasId = root.dataset.canvasId || 'default';
+
+    renderNodes();
+    applyTransform();
+    bindEvents();
+    state.mounted = true;
+
+    loadCanvas(true);
+  }
+
+  function bindEvents() {
+    state.viewport.addEventListener('wheel', onWheel, { passive: false });
+    state.viewport.addEventListener('pointerdown', onPointerDown);
+    state.layer.addEventListener('click', onLayerClick);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  }
+
+  function onWheel(event) {
+    event.preventDefault();
+
+    var rect = state.viewport.getBoundingClientRect();
+    var cx = event.clientX - rect.left;
+    var cy = event.clientY - rect.top;
+
+    var worldX = (cx - state.translateX) / state.scale;
+    var worldY = (cy - state.translateY) / state.scale;
+
+    var factor = event.deltaY > 0 ? 0.92 : 1.08;
+    var next = Math.max(state.minScale, Math.min(state.maxScale, state.scale * factor));
+
+    state.scale = next;
+    state.translateX = cx - (worldX * state.scale);
+    state.translateY = cy - (worldY * state.scale);
+
+    applyTransform();
+    updateZoomLabel();
+  }
+
+  function onPointerDown(event) {
+    if (event.target && event.target.closest && (event.target.closest('.spatial-node-markdown a') || event.target.closest('.spatial-node-toggle'))) {
+      return;
+    }
+
+    var node = event.target.closest('.spatial-node');
+    if (node) {
+      state.nodeDragId = node.dataset.nodeId;
+      var model = findNode(state.nodeDragId);
+      if (!model) return;
+
+      var world = screenToWorld(event.clientX, event.clientY);
+      state.nodeDragOffsetX = world.x - model.x;
+      state.nodeDragOffsetY = world.y - model.y;
+      node.classList.add('dragging');
+      return;
+    }
+
+    state.isPanning = true;
+    state.panStartX = event.clientX;
+    state.panStartY = event.clientY;
+    state.viewport.classList.add('is-panning');
+  }
+
+  function onLayerClick(event) {
+    var toggleBtn = event.target.closest('.spatial-node-toggle');
+    if (toggleBtn) {
+      var toggleNode = toggleBtn.closest('.spatial-node');
+      if (!toggleNode) return;
+      var model = findNode(toggleNode.dataset.nodeId);
+      if (!model) return;
+      model.collapsed = !model.collapsed;
+      renderNodes();
+      return;
+    }
+
+    var link = event.target.closest('.spatial-node-markdown a');
+    if (link) {
+      event.preventDefault();
+      var href = link.getAttribute('href') || '';
+      var sourceEl = link.closest('.spatial-node');
+      var source = sourceEl ? findNode(sourceEl.dataset.nodeId) : null;
+      if (!href) return;
+      var target = findNode(href);
+      if (target) {
+        setStatus('Focused existing node: ' + href);
+        return;
+      }
+      var shouldAdd = window.confirm('Add target node to canvas?\n' + href);
+      if (!shouldAdd) return;
+
+      var baseX = source ? source.x + 320 : 260;
+      var baseY = source ? source.y + 40 : 220;
+      state.nodes.push({
+        id: href,
+        title: 'Linked Resource',
+        uri: href,
+        x: baseX,
+        y: baseY,
+        markdown: 'Added from markdown link\n\nURI: `' + href + '`',
+        collapsed: false,
+      });
+      setStatus('Added linked node: ' + href);
+      renderNodes();
+    }
+  }
+
+  function onPointerMove(event) {
+    if (state.nodeDragId) {
+      var node = findNode(state.nodeDragId);
+      if (!node) return;
+      var world = screenToWorld(event.clientX, event.clientY);
+      node.x = Math.round(world.x - state.nodeDragOffsetX);
+      node.y = Math.round(world.y - state.nodeDragOffsetY);
+      renderNodes();
+      return;
+    }
+
+    if (!state.isPanning) return;
+    state.translateX += event.clientX - state.panStartX;
+    state.translateY += event.clientY - state.panStartY;
+    state.panStartX = event.clientX;
+    state.panStartY = event.clientY;
+    applyTransform();
+  }
+
+  function onPointerUp() {
+    if (state.nodeDragId) {
+      var nodeEl = state.layer.querySelector('.spatial-node.dragging');
+      if (nodeEl) nodeEl.classList.remove('dragging');
+    }
+
+    state.nodeDragId = null;
+    state.isPanning = false;
+    if (state.viewport) state.viewport.classList.remove('is-panning');
+  }
+
+  function renderNodes() {
+    if (!state.layer) return;
+
+    var nodesHtml = state.nodes.map(function (node) {
+      return [
+        '<article class="spatial-node', (node.collapsed ? ' is-collapsed' : ''), '" data-node-id="', escapeHtml(node.id), '" style="left:', node.x, 'px; top:', node.y, 'px;">',
+          '<header class="spatial-node-header">',
+            '<span class="spatial-node-title">', escapeHtml(node.title), '</span>',
+            '<button class="spatial-node-toggle" type="button">', (node.collapsed ? 'Expand' : 'Collapse'), '</button>',
+          '</header>',
+          '<div class="spatial-node-uri">', escapeHtml(node.uri), '</div>',
+          (node.collapsed ? '' : '<div class="spatial-node-markdown">' + renderMarkdown(node.markdown || '') + '</div>'),
+        '</article>'
+      ].join('');
+    }).join('');
+
+    state.layer.innerHTML = nodesHtml;
+
+    var nodeBoxes = {};
+    state.layer.querySelectorAll('.spatial-node').forEach(function (el) {
+      var id = el.dataset.nodeId;
+      var model = findNode(id);
+      if (!id || !model) return;
+      nodeBoxes[id] = {
+        x: model.x,
+        y: model.y,
+        width: el.offsetWidth,
+        height: el.offsetHeight,
+      };
+    });
+
+    var markdownEdges = [];
+    var anchorDotsHtml = [];
+
+    state.layer.querySelectorAll('.spatial-node').forEach(function (nodeEl) {
+      var sourceId = nodeEl.dataset.nodeId;
+      var sourceBox = nodeBoxes[sourceId];
+      if (!sourceBox) return;
+
+      nodeEl.querySelectorAll('.spatial-node-markdown a[href]').forEach(function (linkEl, idx) {
+        var href = linkEl.getAttribute('href') || '';
+        if (!href) return;
+        var linkRect = linkEl.getBoundingClientRect();
+        var nodeRect = nodeEl.getBoundingClientRect();
+        var anchorY = sourceBox.y + (linkRect.top - nodeRect.top) + (linkRect.height / 2);
+        var anchorX = sourceBox.x + sourceBox.width;
+        var targetNode = findNode(href);
+
+        anchorDotsHtml.push('<circle class="spatial-anchor-dot" cx="' + Math.round(anchorX) + '" cy="' + Math.round(anchorY) + '" r="3"></circle>');
+
+        if (targetNode) {
+          markdownEdges.push({
+            id: 'md|' + sourceId + '|' + href + '|' + idx,
+            source: sourceId,
+            target: href,
+            label: 'link',
+            anchorX: anchorX,
+            anchorY: anchorY,
+          });
+        }
+      });
+    });
+
+    var combinedEdges = state.edges.concat(markdownEdges);
+
+    var edgesHtml = combinedEdges.map(function (edge) {
+      var source = nodeBoxes[edge.source];
+      var target = nodeBoxes[edge.target];
+      if (!source || !target) return '';
+
+      var start = (typeof edge.anchorX === 'number' && typeof edge.anchorY === 'number')
+        ? { x: edge.anchorX, y: edge.anchorY }
+        : edgePoint(source, target);
+      var end = edgePoint(target, source);
+      var mx = Math.round((start.x + end.x) / 2);
+      var my = Math.round((start.y + end.y) / 2) - 10;
+
+      return [
+        '<line class="spatial-edge-line', (edge.id.indexOf('md|') === 0 ? ' spatial-edge-line-markdown' : ''), '" x1="', Math.round(start.x), '" y1="', Math.round(start.y), '" x2="', Math.round(end.x), '" y2="', Math.round(end.y), '"></line>',
+        '<text class="spatial-edge-label" x="', mx, '" y="', my, '">', escapeHtml(edge.label || ''), '</text>'
+      ].join('');
+    }).join('');
+
+    var svgHtml = [
+      '<svg class="spatial-edges" width="5000" height="5000" viewBox="0 0 5000 5000" aria-hidden="true">',
+      '<defs><marker id="spatial-edge-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L7,3 z" class="spatial-edge-arrow-path"></path></marker></defs>',
+      edgesHtml,
+      anchorDotsHtml.join(''),
+      '</svg>'
+    ].join('');
+
+    state.layer.insertAdjacentHTML('afterbegin', svgHtml);
+  }
+
+  function applyTransform() {
+    if (!state.layer) return;
+    state.layer.style.transform = 'translate(' + state.translateX + 'px, ' + state.translateY + 'px) scale(' + state.scale + ')';
+  }
+
+  function findNode(id) {
+    for (var i = 0; i < state.nodes.length; i++) {
+      if (state.nodes[i].id === id) return state.nodes[i];
+    }
+    return null;
+  }
+
+  function edgePoint(fromBox, toBox) {
+    var cx = fromBox.x + (fromBox.width / 2);
+    var cy = fromBox.y + (fromBox.height / 2);
+    var tx = toBox.x + (toBox.width / 2);
+    var ty = toBox.y + (toBox.height / 2);
+
+    var dx = tx - cx;
+    var dy = ty - cy;
+
+    if (dx === 0 && dy === 0) {
+      return { x: cx, y: cy };
+    }
+
+    var scaleX = (fromBox.width / 2) / Math.max(Math.abs(dx), 0.0001);
+    var scaleY = (fromBox.height / 2) / Math.max(Math.abs(dy), 0.0001);
+    var scale = Math.min(scaleX, scaleY);
+
+    return {
+      x: cx + (dx * scale),
+      y: cy + (dy * scale),
+    };
+  }
+
+  function screenToWorld(clientX, clientY) {
+    var rect = state.viewport.getBoundingClientRect();
+    var sx = clientX - rect.left;
+    var sy = clientY - rect.top;
+    return {
+      x: (sx - state.translateX) / state.scale,
+      y: (sy - state.translateY) / state.scale,
+    };
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+
+  function renderMarkdown(markdownText) {
+    if (!markdownText) return '';
+
+    if (typeof globalThis.marked !== 'undefined') {
+      try {
+        var rendered = globalThis.marked.parse(markdownText);
+        if (typeof DOMPurify !== 'undefined') {
+          rendered = DOMPurify.sanitize(rendered);
+        }
+        return rendered;
+      } catch (e) {
+        // fall through to escaped plaintext
+      }
+    }
+
+    return escapeHtml(markdownText).replace(/\n/g, '<br>');
+  }
+
+  function resetView() {
+    state.scale = 1;
+    state.translateX = 0;
+    state.translateY = 0;
+    applyTransform();
+    updateZoomLabel();
+  }
+
+  function zoomIn() {
+    state.scale = Math.min(state.maxScale, state.scale * 1.15);
+    applyTransform();
+    updateZoomLabel();
+  }
+
+  function zoomOut() {
+    state.scale = Math.max(state.minScale, state.scale * 0.87);
+    applyTransform();
+    updateZoomLabel();
+  }
+
+  function updateZoomLabel() {
+    var label = document.getElementById('spatial-canvas-zoom');
+    if (!label) return;
+    label.textContent = Math.round(state.scale * 100) + '%';
+  }
+
+
+  function getDocument() {
+    return {
+      nodes: state.nodes.map(function (n) {
+        return {
+          id: n.id,
+          title: n.title,
+          uri: n.uri,
+          x: n.x,
+          y: n.y,
+          markdown: n.markdown || '',
+          collapsed: !!n.collapsed,
+        };
+      }),
+      edges: state.edges.map(function (e) {
+        return { id: e.id, source: e.source, target: e.target, label: e.label || '' };
+      }),
+      viewport: { x: state.translateX, y: state.translateY, zoom: state.scale },
+    };
+  }
+
+  function applyDocument(document) {
+    if (!document || typeof document !== 'object') return;
+    if (Array.isArray(document.nodes)) {
+      state.nodes = document.nodes.map(function (n) {
+        return {
+          id: String(n.id || ''),
+          title: String(n.title || n.id || 'Untitled'),
+          uri: String(n.uri || n.id || ''),
+          x: Number(n.x || 0),
+          y: Number(n.y || 0),
+          markdown: String(n.markdown || ''),
+          collapsed: !!n.collapsed,
+        };
+      });
+    }
+    if (Array.isArray(document.edges)) {
+      state.edges = document.edges.map(function (e) {
+        return {
+          id: String(e.id || (e.source + '->' + e.target)),
+          source: String(e.source || ''),
+          target: String(e.target || ''),
+          label: String(e.label || ''),
+        };
+      });
+    }
+    if (document.viewport && typeof document.viewport === 'object') {
+      state.translateX = Number(document.viewport.x || 0);
+      state.translateY = Number(document.viewport.y || 0);
+      state.scale = Number(document.viewport.zoom || 1);
+    }
+    renderNodes();
+    applyTransform();
+    updateZoomLabel();
+  }
+
+  function setStatus(message, isError) {
+    var el = document.getElementById('spatial-canvas-status');
+    if (!el) return;
+    el.textContent = message || '';
+    el.classList.toggle('error', !!isError);
+  }
+
+  async function saveCanvas() {
+    try {
+      var response = await fetch('/api/canvas/' + encodeURIComponent(state.canvasId || 'default'), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ document: getDocument() }),
+      });
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      var data = await response.json();
+      setStatus('Saved ' + (data.updated_at || ''));
+      if (window.showToast) window.showToast('Canvas saved');
+    } catch (error) {
+      setStatus('Save failed', true);
+      if (window.showToast) window.showToast('Canvas save failed');
+    }
+  }
+
+  async function loadCanvas(silent) {
+    try {
+      var response = await fetch('/api/canvas/' + encodeURIComponent(state.canvasId || 'default'));
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      var data = await response.json();
+      if (data && data.document) {
+        applyDocument(data.document);
+        if (!silent) {
+          setStatus('Loaded ' + (data.updated_at || ''));
+          if (window.showToast) window.showToast('Canvas loaded');
+        }
+      }
+    } catch (error) {
+      if (!silent) {
+        setStatus('Load failed', true);
+        if (window.showToast) window.showToast('Canvas load failed');
+      }
+    }
+  }
+
+
+  function mergeSubgraph(payload) {
+    if (!payload || !Array.isArray(payload.nodes)) return;
+
+    var existingNodeIds = {};
+    state.nodes.forEach(function (n) { existingNodeIds[n.id] = true; });
+
+    var centerX = (state.viewport ? state.viewport.clientWidth : 900) / 2;
+    var centerY = (state.viewport ? state.viewport.clientHeight : 600) / 2;
+
+    payload.nodes.forEach(function (node, idx) {
+      var nodeId = String(node.id || '');
+      if (!nodeId || existingNodeIds[nodeId]) return;
+
+      var angle = (idx / Math.max(payload.nodes.length, 1)) * Math.PI * 2;
+      var radius = 220 + (idx % 5) * 30;
+
+      state.nodes.push({
+        id: nodeId,
+        title: String(node.label || node.id || 'Resource'),
+        uri: nodeId,
+        x: Math.round((centerX - state.translateX) / state.scale + Math.cos(angle) * radius),
+        y: Math.round((centerY - state.translateY) / state.scale + Math.sin(angle) * radius),
+        markdown: 'Loaded from RDF subgraph\n\nURI: `' + nodeId + '`',
+      });
+      existingNodeIds[nodeId] = true;
+    });
+
+    if (Array.isArray(payload.edges)) {
+      var existingEdgeIds = {};
+      state.edges.forEach(function (e) { existingEdgeIds[e.id] = true; });
+      payload.edges.forEach(function (edge) {
+        var source = String(edge.source || '');
+        var target = String(edge.target || '');
+        var predicate = String(edge.predicate || 'relatedTo');
+        if (!source || !target) return;
+        var edgeId = source + '|' + predicate + '|' + target;
+        if (existingEdgeIds[edgeId]) return;
+        state.edges.push({
+          id: edgeId,
+          source: source,
+          target: target,
+          label: String(edge.predicate_label || predicate),
+        });
+        existingEdgeIds[edgeId] = true;
+      });
+    }
+
+    renderNodes();
+    applyTransform();
+  }
+
+  async function loadNeighbors() {
+    var seed = null;
+    if (state.nodes.length > 0) seed = state.nodes[0].uri;
+    var rootUri = window.prompt('Root URI to expand', seed || '');
+    if (!rootUri) return;
+
+    try {
+      var response = await fetch('/api/canvas/subgraph?root_uri=' + encodeURIComponent(rootUri) + '&depth=1');
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      var data = await response.json();
+      mergeSubgraph(data);
+      setStatus('Loaded neighbors for ' + rootUri);
+      if (window.showToast) window.showToast('Neighbors loaded');
+    } catch (error) {
+      setStatus('Neighbor load failed', true);
+      if (window.showToast) window.showToast('Neighbor load failed');
+    }
+  }
+
+  window.SemPKMCanvas = {
+    mount: mountCanvas,
+    zoomIn: zoomIn,
+    zoomOut: zoomOut,
+    resetView: resetView,
+    save: saveCanvas,
+    load: function () { return loadCanvas(false); },
+    exportState: getDocument,
+    importState: applyDocument,
+    loadNeighbors: loadNeighbors,
+    expandNeighbors: loadNeighbors,
+  };
+
+  document.body.addEventListener('htmx:afterSwap', function (event) {
+    if (event && event.target && event.target.querySelector && event.target.querySelector('#spatial-canvas-root')) {
+      state.mounted = false;
+      mountCanvas();
+    }
+  });
+})();

--- a/frontend/static/js/workspace.js
+++ b/frontend/static/js/workspace.js
@@ -145,6 +145,8 @@
       url = '/browser/views/card/' + encodeURIComponent(viewId);
     } else if (viewType === 'graph') {
       url = '/browser/views/graph/' + encodeURIComponent(viewId);
+    } else if (viewType === 'canvas') {
+      url = '/browser/canvas';
     } else {
       url = '/browser/views/table/' + encodeURIComponent(viewId);
     }
@@ -670,6 +672,27 @@
   }
   window.openDocsTab = openDocsTab;
 
+
+  function openCanvasTab() {
+    var tabKey = 'special:canvas';
+    var dv = window._dockview;
+    if (!dv) return;
+
+    var existing = dv.panels.find(function(p) { return p.id === tabKey; });
+    if (existing) { existing.api.setActive(); return; }
+
+    if (!window._tabMeta) window._tabMeta = {};
+    window._tabMeta[tabKey] = { label: 'Spatial Canvas', dirty: false };
+
+    dv.api.addPanel({
+      id: tabKey,
+      component: 'special-panel',
+      params: { specialType: 'canvas', isView: false, isSpecial: true },
+      title: 'Spatial Canvas'
+    });
+  }
+  window.openCanvasTab = openCanvasTab;
+
   // --- Keyboard Shortcuts ---
 
   var _keydownHandler = null;
@@ -1014,6 +1037,7 @@
 
       // Dynamically load available views into command palette
       _loadViewCommandPaletteEntries(ninja);
+      _addCanvasPaletteEntry(ninja);
 
       // Initialize FTS search integration for Ctrl+K palette
       _initFtsSearch(ninja);
@@ -1037,6 +1061,20 @@
         }
       });
     }
+  }
+
+
+  function _addCanvasPaletteEntry(ninja) {
+    if (!ninja || !ninja.data) return;
+    var exists = ninja.data.find(function (d) { return d.id === 'nav-spatial-canvas'; });
+    if (exists) return;
+
+    ninja.data = ninja.data.concat([{
+      id: 'nav-spatial-canvas',
+      title: 'Open: Spatial Canvas',
+      section: 'Views',
+      handler: function () { openCanvasTab(); }
+    }]);
   }
 
   function _loadViewCommandPaletteEntries(ninja) {


### PR DESCRIPTION
### Motivation

- Add an incremental Spatial Canvas feature integrated into the existing HTMX/Dockview workspace to ship a thin vertical slice (C0) before a full React Flow island.  
- Provide per-user persistence and simple RDF neighborhood expansion endpoints to enable save/load and neighbor exploration in the MVP.  

### Description

- Add a project-level plan ` .planning/research/spatial-rdf-canvas-integration-plan.md` describing the architecture, phased roadmap, and locked decisions (Track A packaging, per-user storage, markdown links only).  
- Introduce a new backend canvas package with `app/canvas/router.py`, `app/canvas/schemas.py`, `app/canvas/service.py`, and `app/canvas/__init__.py`, and register the router in `app/main.py`; this adds `GET /api/canvas/{id}`, `PUT /api/canvas/{id}`, and `GET /api/canvas/subgraph` endpoints.  
- Implement persistence backed by existing `user_settings` via `CanvasService` using keys `canvas.{id}.document` and `canvas.{id}.meta` and include optimistic `updated_at` metadata.  
- Add UI entry points and minimal host template: new route `GET /canvas` in `backend/app/browser/router.py`, the template `backend/app/templates/browser/canvas_page.html`, and include the canvas script in `backend/app/templates/base.html`.  
- Provide a framework-free client prototype at `frontend/static/js/canvas.js` implementing pan/zoom, draggable resource cards, markdown-render parsing, save/load, neighbor expansion via `/api/canvas/subgraph`, and a small JS API `window.SemPKMCanvas`.  
- Add styling in `frontend/static/css/workspace.css` for canvas layout, nodes, edges, anchors, and toolbar, and wire workspace integrations in `frontend/static/js/workspace.js` and `backend/app/templates/browser/views_explorer.html` to open the canvas tab and add a palette entry.  

### Testing

- No automated tests were added or executed as part of this change; backend and frontend behavior should be covered by the planned tests in the integration plan (backend `pytest` for canvas CRUD and subgraph contract tests, and E2E Playwright scenarios).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a91f7f7004832d8a2302661917523e)