### PR TITLE
Add LinkML integration assessment research doc

### DIFF
--- a/.planning/research/linkml-integration-assessment.md
+++ b/.planning/research/linkml-integration-assessment.md
@@ -1,0 +1,136 @@
+# LinkML Integration Assessment
+
+**Date:** 2026-08-20
+**Status:** Research / recommendation — no code changes proposed for the current user-testing window
+
+## TL;DR
+
+LinkML fits SemPKM well — but as a **compile-time authoring layer for Mental Model bundles**, not as a runtime component. The recommendation is:
+
+- **Do:** author Mental Model schemas as LinkML YAML and *generate* the existing bundle artifacts (OWL ontology JSON-LD + SHACL shapes JSON-LD) with a small custom generator. The generated files stay committed in `models/*/`, the bundle format stays the installation contract, and the runtime (RDF4J, pyshacl, owlrl, `ShapesService`) is untouched.
+- **Don't:** replace SHACL as the runtime schema representation, put LinkML in the request path, or attempt to cover gist, SHACL-AF rules, ViewSpec SPARQL, or runtime user-created classes with it.
+
+This addresses the two real pain points LinkML is built for — keeping four parallel hand-authored artifacts consistent, and the open "Alembic-style migrations for RDF models" idea (`.gsd/QUEUE.md`) — with zero blast radius on the running app. Nothing in the first two phases below changes runtime behavior, so it is safe to pursue during user testing.
+
+## What LinkML is (one paragraph)
+
+[LinkML](https://linkml.io) is a YAML-based schema language with a rich metamodel (classes, slots, enums, types, inheritance, slot groups, inverses, annotations) and a generator toolchain: `gen-owl`, `gen-shacl`, `gen-jsonld-context`, `gen-pydantic`, `gen-doc`, plus `linkml-validate` for validating instance data (JSON/YAML/RDF) against a schema, `schema-automator` for bootstrapping schemas *from* existing OWL, and LinkML-Map for declarative data transformation between schema versions. One YAML source, many derived artifacts.
+
+## Current state (what the assessment found)
+
+SemPKM already has a clean semantics-native architecture. The relevant facts:
+
+1. **Mental Models are a hand-rolled schema compiler input without the compiler.** Each of the 8 bundled models hand-authors four parallel JSON-LD artifacts (ontology, shapes, views, seed) plus `manifest.yaml`, ~10,200 lines of JSON-LD for ontologies + shapes alone. The same class/property information is restated in the ontology (`owl:Class`, `rdfs:domain/range`), the shapes (`sh:targetClass`, `sh:path`, `sh:datatype`/`sh:class`), the views (full IRIs embedded in SPARQL strings), and the seed data. Consistency is enforced only partially, at install time, by `backend/app/models/validator.py`.
+
+2. **The OWL/SHACL profile in actual use is small and closed.** Census across all 8 models: `owl:Class` ×74, `owl:DatatypeProperty` ×200, `owl:ObjectProperty` ×103, `owl:inverseOf` ×44, `rdfs:subClassOf` ×58, `owl:SymmetricProperty` ×2, one `owl:unionOf`; no `owl:Restriction`, no cardinality axioms. SHACL side: the documented SHACL-UI profile (`orig_specs/spec/shacl-ui/shacl-ui-profile.md`) is ~15 SHACL Core terms (`sh:path/name/datatype/class/in/minCount/maxCount/order/group/defaultValue/pattern/nodeKind` + `sh:PropertyGroup`) plus one custom annotation, `sempkm:editHelpText` (×363). Everything in this profile has a direct LinkML counterpart (see mapping table below).
+
+3. **The runtime consumes triples, not files.** Bundles are loaded via rdflib into named graphs (`urn:sempkm:model:{id}:{artifact}`); forms come from `ShapesService` traversing the shapes graph into the `NodeShapeForm`/`PropertyShape`/`PropertyGroup` dataclasses (`app/services/shapes.py`), which are the narrow waist consumed by ~9 modules; validation is async pyshacl; inference is owlrl + SHACL-AF rules. None of this needs to know or care how the JSON-LD files were produced.
+
+4. **There is no schema-evolution story.** `.gsd/QUEUE.md` ("Mental Model Schema Migrations", status: Idea) records the pain verbatim: binary install/uninstall, uninstall blocked once ABox data exists, "adding `sh:description` or `editHelpText` to shapes requires manual SPARQL graph surgery", "model authors have no iteration loop once a model is in use". Only `ModelService.refresh_artifacts()` (safe RBox refresh) has shipped.
+
+5. **LinkML, ShEx, and JSON Schema have never been evaluated.** Zero LinkML mentions anywhere in code, docs, planning, or git history. The design docs (`.gsd/design/MENTAL-MODELS-EXPANSION-DESIGN.md`) already sketch new models as property tables that read almost exactly like LinkML slot definitions.
+
+## Where LinkML fits
+
+### 1. Single-source authoring for Mental Model bundles (the core fit)
+
+One LinkML YAML file per model becomes the source of truth; a `scripts/` compiler generates the bundle artifacts that are *already* the installation contract:
+
+```
+models-src/crm/crm.yaml          (LinkML, hand-authored)
+        │  gen (custom, built on linkml-runtime SchemaView)
+        ▼
+models/crm/ontology/crm.jsonld   (generated OWL)
+models/crm/shapes/crm.jsonld     (generated SHACL, SemPKM UI profile)
+models/crm/manifest.yaml         (partially generated, or kept hand-authored)
+```
+
+What this buys:
+
+- **Consistency by construction.** A property is declared once; its `rdfs:domain/range`, its `sh:path/datatype/class`, and its cardinality can no longer drift apart. Today that drift is only partially caught (and see the validator bug in "Side findings").
+- **~3–4× less authored text.** A LinkML slot declaration of ~6 lines replaces ~15 lines of ontology JSON-LD + ~10 lines of shapes JSON-LD.
+- **CI-checkable models.** `linkml-validate` can validate `seed/*.jsonld` against the schema at build time (today seed data errors only surface as post-install lint results), and a CI job can assert `generated == committed` so the artifacts can never go stale.
+- **A dramatically lower authoring bar.** "Write a YAML file with classes and slots" is a much smaller ask for community model authors than "hand-write four mutually-consistent JSON-LD documents" — relevant to the marketplace ambitions.
+- **Bootstrapping is cheap.** `schema-automator import-owl` can draft the LinkML YAML for the 8 existing models from their current ontologies; the shapes' UI metadata (order, groups, helptext) gets folded in by a one-off script.
+
+Importantly, the **generated files stay committed in the repo** and mounted/packaged exactly as today. Marketplace archives, the install pipeline, `refresh_artifacts`, and every runtime consumer see no difference. The Docker "no remote `@context`" constraint (`loader.py:_check_no_remote_context`) is satisfied by inlining contexts at generation time.
+
+### 2. The schema-migrations feature (the strategic fit)
+
+This is the biggest long-term payoff. The QUEUE.md wish — "Alembic-style migrations for RDF models" — is very hard to build against free-form RDF graphs (diffing two arbitrary OWL+SHACL graph pairs and classifying the changes is an open-ended problem). Against two versions of a LinkML schema it becomes tractable:
+
+- **Schema diff** between v1.0.0 and v1.1.0 YAML is a structured, classifiable operation: slot added (append-only TBox addition → safe), enum value added (safe), slot renamed / datatype changed / class removed (needs ABox transformation).
+- **ABox transformations** can be expressed declaratively with LinkML-Map, or the diff can drive generation of the SPARQL UPDATE against `urn:sempkm:current` that the migration executes.
+- The existing `refresh_artifacts()` becomes the executor for the "safe" class of changes; the registry's semver field becomes meaningful.
+
+Without LinkML (or something like it), the migrations feature would end up inventing a schema-description layer anyway, just ad hoc.
+
+### 3. Secondary wins (optional, later)
+
+- **`gen-doc`** → per-model reference pages for `docs/guide/39-mental-model-catalog.md` and the marketplace, generated instead of hand-written.
+- **`gen-pydantic`** → typed DTOs for the public `/api/shapes` / `/api/types` surface consumed by the browser extension and mobile app, replacing hand-maintained dicts.
+- **`gen-jsonld-context`** → a published context for the SemPKM vocabulary (currently absent).
+
+## Where LinkML does NOT fit — leave these guts alone
+
+| Area | Why LinkML stays out |
+|---|---|
+| **Runtime validation** (pyshacl queue, lint panel) | SHACL is the right runtime lingua franca; LinkML *generates* SHACL, it doesn't replace it. No change. |
+| **RDF4J storage / named graphs / event sourcing** | LinkML is schema tooling, not a store. The triples-in-named-graphs contract is load-bearing for 40+ modules. |
+| **`ShapesService` and the form pipeline** | It consumes the shapes *graph*, which keeps existing exactly as-is (now generated). The `NodeShapeForm` narrow waist is untouched. |
+| **Runtime user-created classes** (`app/ontology/service.py` CRUD, `urn:sempkm:user-types`) | LinkML is file/compile-time; users minting classes in the UI is a runtime path that writes triples directly. These two worlds already live in separate named graphs — keep it that way. Folding user types into LinkML would mean round-tripping YAML at runtime for no benefit. |
+| **gist upper ontology** | Full OWL 2 DL with `owl:equivalentClass`/`owl:intersectionOf` class expressions that LinkML cannot represent (and which the code already flattens via `_extract_implied_subclasses`). gist remains a vendored artifact; LinkML classes simply declare gist superclasses as IRIs. |
+| **SHACL-AF rules** (`models/*/rules/*.ttl`) | SPARQL CONSTRUCT rules are outside LinkML's model. Keep hand-authored Turtle; the compiler passes them through. |
+| **ViewSpecs** | SPARQL strings + renderer config are not schema. Keep hand-authored — though the compiler *could* template the boring default table/card/graph specs from the class's slots, and `register_generic_views()` already reduces the need for hand-written ones. |
+
+## Construct mapping (SemPKM profile → LinkML)
+
+| SemPKM (OWL + SHACL) | LinkML | Notes |
+|---|---|---|
+| `owl:Class` + `rdfs:label`/`comment` | `class` + `title`/`description` | direct |
+| `rdfs:subClassOf` (incl. gist parents) | `is_a` / `class_uri` + external parent IRI | direct |
+| `owl:DatatypeProperty` + `rdfs:domain/range` | slot with scalar `range` | direct |
+| `owl:ObjectProperty` + `sh:class` | slot with class `range` | direct |
+| `owl:inverseOf` (×44) | slot `inverse` | direct |
+| `owl:SymmetricProperty` | slot `symmetric` | direct |
+| `sh:minCount`/`sh:maxCount` | `required` / `multivalued` | direct |
+| `sh:in` dropdown lists (×65) | `enum` | direct, and enums become reusable |
+| `sh:defaultValue` | `ifabsent` | direct |
+| `sh:pattern`, min/max bounds | `pattern`, `minimum_value`/`maximum_value` | direct |
+| `sh:order` (×706) | slot `rank` | direct |
+| `sh:group` / `sh:PropertyGroup` (×167) | `slot_group` | direct concept match; generator emits the `PropertyGroup` nodes |
+| `sh:name` display label | slot `title` | direct |
+| `sempkm:editHelpText` (×363) | `annotations` | generator maps annotation → triple |
+| Manifest icons/colors/settings | `annotations` on classes, or keep in manifest | either works; keeping manifest hand-authored is simplest |
+| Reuse of dcterms/foaf/schema/skos | `slot_uri` per slot | direct — LinkML is explicitly built for vocabulary reuse |
+
+**Gap:** stock `gen-shacl` and `gen-owl` will not emit the UI profile (`sh:order`, `sh:group`, `sh:name`, `sh:defaultValue`, `editHelpText`) in SemPKM's exact shape. The right move is a **custom generator** (~300–600 lines on `linkml-runtime` `SchemaView`) that emits precisely the SemPKM SHACL-UI profile and the OWL profile above. Because the measured profile is small and closed, this is a bounded, well-specified piece of work — much cheaper than bending the stock generators.
+
+## Phased adoption (no gut-ripping)
+
+**Phase 0 — spike (no user-visible change, safe during user testing).**
+Pick the smallest model (`rss-feeds`: 140-line ontology, 232-line shapes). Hand-write its LinkML YAML, build the generator, and prove semantic equivalence with `rdflib.compare.isomorphic` between generated and current graphs. Exit criterion: generated bundle installs and passes the full e2e suite unchanged.
+
+**Phase 1 — adopt for authoring.**
+Bootstrap the other 7 models with `schema-automator` + a shapes-metadata merge script; commit YAML sources alongside generated artifacts; add the CI freshness check; update `docs/guide/19-creating-mental-models.md` with the YAML authoring path (the raw JSON-LD path remains valid — the bundle format is unchanged, so third-party authors are never forced onto LinkML). Still zero runtime change.
+
+**Phase 2 — schema migrations.**
+Build the QUEUE.md migrations feature on LinkML schema diffs: classify changes (safe RBox refresh vs. ABox-transforming), generate migration plans, track versions in the model registry. This is the first phase that touches runtime code, and by then the schema source of truth is already structured.
+
+**Phase 3 — opportunistic codegen.**
+`gen-doc` for the model catalog, `gen-pydantic` for API DTOs, published JSON-LD context.
+
+## Risks and costs
+
+- **New toolchain dependency** (Python `linkml`, `linkml-runtime`) — build-time only if the generator runs in CI/scripts; it never needs to be in the API container image.
+- **Two representations during transition** — mitigated by the CI freshness check; the generated artifact is always what ships.
+- **Custom generator maintenance** — bounded by the closed profile; changes to the SHACL-UI profile (rare, spec'd in `orig_specs/spec/shacl-ui/`) imply generator updates.
+- **Expressivity ceiling** — if models ever need real OWL restrictions or exotic SHACL, those constructs would be escape-hatched (LinkML supports embedding raw annotations, and `rules/*.ttl` already demonstrates the pattern of hand-authored companion artifacts). Today's census shows nothing in the models needs it.
+- **Not worth it if** model authoring stops (all 8 models frozen, no marketplace growth) — the payoff scales with the number and churn of models.
+
+## Side findings (independent of LinkML, worth fixing)
+
+1. **View reference-integrity check never fires.** `app/models/validator.py:20` binds `SEMPKM_TARGET_CLASS = urn:sempkm:targetClass`, but all shipped views files and `app/views/service.py:167` use `urn:sempkm:vocab:targetClass` — so check #4 in `validate_reference_integrity` silently matches nothing.
+2. **Write path ignores declared datatypes.** `_to_rdf_value()` in `app/commands/handlers/object_create.py:50-79` guesses `xsd:date`/`xsd:dateTime`/IRI-ness by string sniffing instead of consulting the property's `sh:datatype` — a source of lint noise that shape-driven coercion would eliminate.
+3. **`entailment_defaults` is not a declared field** on `ManifestSchema` (`app/models/manifest.py`), so Pydantic silently drops it there while `app/inference/` reads it from raw YAML — worth unifying.
+4. **pyshacl runs without `ont_graph`**, so validation sees no OWL axioms (`app/services/validation.py`); intentional or not, it should be a recorded decision.

--- a/TOUR.md
+++ b/TOUR.md
@@ -475,10 +475,95 @@ _These need API keys/OAuth to test fully. Test at minimum: settings UI loads, co
 | 63 | 🔴 Broken | object-crud | 2 | `object.create` does not set `dcterms:created` automatically — new objects have no creation timestamp. The "Eisenhower Matrices Table" shows the seed data row with a CREATED value but the user-created row has an empty CREATED cell. | Create any object → view in table → CREATED column is empty |
 | 64 | 🔴 Broken | views | 5 | "Browse: Eisenhower Quadrant" view does not exist in the VIEWS section — the ViewSpec didn't load into the triplestore. Root cause is #4a (model installer only loading a fraction of artifacts). All business-planning custom renderers are effectively broken. | Explorer → VIEWS → no quadrant entry |
 | 65 | 🟢 Polish | object-crud | 2 | Object tab header needs a refresh button (cycle icon, same as explorer panel) next to the star/favorite icon. Currently no way to reload an object without closing and reopening the tab. | Any object tab → no refresh action |
+| 66 | 🟡 Bug | model-mgmt | 1 | Archive validator's view→class reference-integrity check never fires — it looks for predicate `urn:sempkm:targetClass` but all views files (and the runtime) use `urn:sempkm:vocab:targetClass`. A model whose ViewSpec targets a nonexistent class installs without error. Detailed fix notes below. | Install a model with a views file targeting a bogus class → no validation error |
+| 67 | 🟡 Bug | object-crud | 2 | Write path ignores declared SHACL datatypes — `_to_rdf_value()` guesses `xsd:date`/`xsd:dateTime`/IRI-ness by string sniffing instead of consulting the property's `sh:datatype`/`sh:class`. Mis-typed literals cause SHACL lint violations and wrong sort/filter behavior in views. Affects all 4 write handlers via the shared helper. Detailed fix notes below. | Create object with a `sh:datatype xsd:boolean` field → value stored as plain string literal → lint flags datatype mismatch |
+| 68 | 🟡 Bug | inference | 18 | `entailment_defaults` is not a declared field on `ManifestSchema` — Pydantic silently drops it, and inference + admin code work around this by re-reading the raw manifest YAML in two separate places. No schema validation on the key, and the workaround readers can drift. Detailed fix notes below. | Add a typo'd `entailment_defaults` key to a manifest → installs silently, defaults ignored |
+| 69 | 🟡 Bug | validation | 9 | pyshacl runs without any ontology graph — validation sees no `rdfs:subClassOf`/OWL axioms, so an object typed as a subclass fails `sh:class` constraints that name the superclass (e.g. a `bpkm:Note` referenced by a property constrained to `gist:FormattedContent` is flagged). Inferred triples in `urn:sempkm:inferred` are also excluded from the validated data. Detailed fix notes below. | Reference a subclass-typed object from a property whose `sh:class` names the parent class → false-positive lint violation |
 
 **Severity:** 🔴 Broken (feature doesn't work) · 🟡 Bug (works but wrong) · 🟢 Polish (cosmetic/UX)
 
 **Category:** `model-mgmt` · `object-crud` · `workspace` · `views` · `canvas` · `sparql` · `search` · `validation` · `vfs` · `import` · `apps` · `sync` · `copilot` · `auth` · `identity` · `dashboard` · `workflow` · `inference` · `events` · `docs` · `ui-quality`
+
+---
+
+## Fix Notes: #66–#69 (backend model layer)
+
+> Found during the 2026-08-20 LinkML integration assessment (`.planning/research/linkml-integration-assessment.md`). All four verified against current `main`. File:line references are exact as of that date.
+
+### #66 — Dead view reference-integrity check (wrong predicate IRI)
+
+**Root cause:** `backend/app/models/validator.py:20` defines
+
+```python
+SEMPKM_TARGET_CLASS = URIRef("urn:sempkm:targetClass")
+```
+
+but every shipped views file binds `"sempkm": "urn:sempkm:vocab:"` (verified across all 8 `models/*/views/*.jsonld`), and the runtime reads views with `urn:sempkm:vocab:targetClass` (`backend/app/views/service.py:38` defines `SEMPKM_VOCAB = "urn:sempkm:vocab:"`, used at line 167). Check #4 in `validate_reference_integrity()` (the loop over `views.triples((None, SEMPKM_TARGET_CLASS, None))`, ~line 168) therefore iterates zero triples and can never report an issue.
+
+**Fix:**
+1. Change the constant to `URIRef("urn:sempkm:vocab:targetClass")`.
+2. Better: define the vocab namespace once (e.g. `SEMPKM_VOCAB = "urn:sempkm:vocab:"` in `backend/app/rdf/namespaces.py`) and derive both the validator constant and `views/service.py:38` from it, so they can't drift again.
+
+**Verify:** unit test in `backend/tests/` — build a `ModelArchive` whose views graph contains a `sempkm:ViewSpec` with `urn:sempkm:vocab:targetClass` pointing at a class **not** in the ontology graph, call `validate_archive`, assert one error with rule `ref-integrity-view-class`. This test fails before the fix (no error reported) and passes after. Also re-run `pytest backend/tests -k validator` and confirm the 8 bundled models still validate cleanly (`test_model_audit.py` covers install).
+
+**Gotcha:** after the fix, any *existing* model archive with a broken view target will start failing installation — check all 8 bundled models' views files reference real ontology classes before merging (the check only applies to targets inside the model's own namespace, so gist/external targets are unaffected).
+
+### #67 — Write path ignores declared `sh:datatype` (string-sniffing coercion)
+
+**Root cause:** `_to_rdf_value()` at `backend/app/commands/handlers/object_create.py:49-76` converts form values to RDF terms purely by inspecting the Python value: strings starting with `http(s)://`/`urn:` become IRIs, ISO-8601-looking strings become `xsd:dateTime`/`xsd:date`, everything else becomes an untyped string literal. The SHACL `sh:datatype` declared on the property shape is never consulted. The helper is shared — imported and called from:
+- `object_create.py:116,119`
+- `object_patch.py:84`
+- `edge_create.py:56`
+- `edge_patch.py:38`
+
+**Symptoms:** booleans arrive from forms as `"true"`/`"false"` and are stored as plain string literals (the `isinstance(value, bool)` branch never fires for form input); integers/decimals stored as strings; a free-text field whose value happens to start with `urn:` becomes a URIRef; all of which produce SHACL datatype-mismatch lint results and break typed sorting/filtering in table views.
+
+**Fix (shape-driven coercion with sniffing as fallback):**
+1. Extend the helper signature: `_to_rdf_value(value, *, expected_datatype: str | None = None, is_object_ref: bool = False)`.
+   - `expected_datatype` (an XSD IRI string) → emit `Literal(value, datatype=URIRef(expected_datatype))`, converting `"true"/"false"` → boolean, numeric strings → int/decimal first so rdflib serializes canonically.
+   - `is_object_ref` (property has `sh:class` or `sh:nodeKind sh:IRI`) → emit `URIRef(value)`, error if not IRI-shaped.
+   - Neither → current sniffing behavior (back-compat for untyped/unknown properties, e.g. RDF import and user-created types with no shape).
+2. Thread the shape info in at the dispatch layer, not inside the pure handlers: in `backend/app/commands/dispatcher.py`, before invoking the handler, resolve the object's type → `ShapesService.get_form_for_type()` (`backend/app/services/shapes.py:356-400`, already TTL-cached) → build `{predicate_iri: PropertyShape}` and pass it through to the handlers (`PropertyShape` already carries `datatype` and `target_class` fields, `shapes.py:30-66`). For edge handlers, the predicate's shape comes from the source object's type.
+3. Update all 4 handlers to pass the per-predicate shape into `_to_rdf_value`.
+
+**Verify:** unit tests on `_to_rdf_value` per datatype (`xsd:boolean`, `xsd:integer`, `xsd:decimal`, `xsd:date`, `xsd:dateTime`, `xsd:anyURI`, `sh:class` ref, no-shape fallback). Integration: create a Task with a boolean/int field via `POST /api/commands`, SPARQL the stored literal's datatype, assert typed. E2E: `e2e/tests/04-validation/` — a freshly created valid object should produce zero datatype lint results.
+
+**Gotcha:** existing stored data keeps its old (untyped) literals — this fix is forward-only. Don't attempt migration here; note it as a follow-up (relates to the "Mental Model Schema Migrations" idea in `.gsd/QUEUE.md`). Watch `sh:in` dropdowns: their values are plain strings by design; only coerce when `sh:datatype` says so.
+
+### #68 — `entailment_defaults` silently dropped by `ManifestSchema`
+
+**Root cause:** `ManifestSchema` (`backend/app/models/manifest.py:60-122`) declares `settings` and `icons` but **not** `entailment_defaults`. Pydantic's default `extra="ignore"` silently discards the key during `parse_manifest()`. Two places work around this by re-reading the raw YAML with their own parsing loops:
+- `backend/app/inference/service.py:664-665`
+- `backend/app/admin/router.py:1386-1410` (`_load_entailment_defaults`)
+
+Consequences: the key gets zero schema validation (a typo'd entailment name or non-bool value is silently accepted/ignored), and the two ad-hoc readers can drift from each other and from the manifest spec.
+
+**Fix:**
+1. Add to `ManifestSchema` (next to `settings`/`icons`):
+   ```python
+   entailment_defaults: dict[str, bool] = Field(default_factory=dict)
+   ```
+   Optionally validate keys against the known entailment types in `backend/app/inference/entailments.py` — warn (don't fail install) on unknown keys, since older/newer models may name entailments this version doesn't know.
+2. Replace both raw-YAML readers with the parsed manifest: `_load_entailment_defaults` in `admin/router.py` and the block in `inference/service.py:655-670` should call `parse_manifest(model_dir)` (or better, read from the model registry if the parsed manifest is stored there at install time) and return `manifest.entailment_defaults`.
+3. Grep for any other raw-YAML manifest reads while in there (`rg "yaml.safe_load" backend/app`) and consolidate on `parse_manifest`.
+
+**Verify:** unit test — manifest YAML with `entailment_defaults: {inverse_properties: true, subclass_transitivity: false}` parses into the field; manifest with a bogus value type (`entailment_defaults: {x: "yes"}`) raises a Pydantic error. Regression: `pytest backend/tests -k "manifest or inference"`; the admin model-detail Inference section (bug #8's screen) still shows correct per-model defaults.
+
+**Gotcha:** `ppv` is the model that ships manifest extras — confirm its manifest still parses and its inference defaults still apply after the change (`test_ppv_ontology.py`).
+
+### #69 — pyshacl validates without ontology axioms (`ont_graph` absent)
+
+**Root cause:** `ValidationService.validate()` at `backend/app/services/validation.py:52-119` CONSTRUCTs **only** `urn:sempkm:current` as the data graph (lines 72-74) and calls `pyshacl.validate(data_graph, shacl_graph=..., advanced=True)` with no `ont_graph` and no inference (lines 99-106). The shapes loader (`model_shapes_loader`, `backend/app/services/models.py:1372-1441`) merges shapes + rules graphs but no ontologies. So SHACL validation has no knowledge of `rdfs:subClassOf`, `owl:inverseOf`, etc.
+
+**Concrete failure:** models subclass gist (`bpkm:Note rdfs:subClassOf gist:FormattedContent`). A property shape with `sh:class gist:FormattedContent` (or `sh:class` naming any superclass) flags every reference to a subclass-typed object as a violation, because the data graph contains only `?x a bpkm:Note` and pyshacl can't derive the supertype. Separately, triples materialized by the inference engine into `urn:sempkm:inferred` (inverse edges etc.) are invisible to validation.
+
+**Fix — two options; pick one and record it in `.gsd/DECISIONS.md`:**
+- **Option A (recommended): include the inferred graph in the data.** Change the CONSTRUCT to `FROM <urn:sempkm:current> FROM <urn:sempkm:inferred>` (named-graph IRIs are in `backend/app/rdf/namespaces.py:79-91`). The inference engine (`backend/app/inference/service.py`, owlrl OWL 2 RL) already materializes subclass/inverse entailments there, so validation sees exactly what the user sees, at zero extra per-run cost. Note the interaction: only *enabled* entailment types are materialized, and user-dismissed inferred triples are excluded — that's arguably correct ("validate what's visible") but is a semantic choice worth writing down. Also add the *type hierarchy itself* (model ontology graphs + `urn:sempkm:ontology:gist`) via `ont_graph=` **without** an `inference=` argument, so pyshacl's own `sh:class` evaluation can walk `rdfs:subClassOf` — pyshacl handles subclass traversal for `sh:class` natively when the hierarchy is present.
+- **Option B: full pyshacl-side inference.** Pass `ont_graph=` (merged model ontologies + gist) plus `inference="rdfs"`. Self-contained, but re-computes the closure over the whole current graph on **every** validation run (it already CONSTRUCTs the full graph each time — see bug #32's performance findings) and duplicates work the inference engine does. Avoid unless Option A proves insufficient.
+
+**Verify:** integration test — install basic-pkm, create a shape constraint `sh:class gist:FormattedContent` on a test property, link a `bpkm:Note`, run validation, assert conforms. Before the fix this reports a violation; after, it passes. Then run the full validation-pipeline suite (`test_validation_pipeline.py`, `test_cross_model_validation.py`) and `e2e/tests/04-validation/` — expect some previously-reported violations to legitimately disappear; eyeball the diff to confirm none of the *intended* violations (required-field, datatype, `sh:in`) got swallowed.
+
+**Gotcha:** watch validation latency after adding graphs (gist is ~138 KB Turtle, parsed per run unless cached) — cache the parsed ontology graph in the service alongside the existing shapes cache pattern (`test_shapes_cache.py` shows the convention).
 
 ---
 


### PR DESCRIPTION
Assesses where LinkML fits in SemPKM: recommends it as a compile-time
authoring layer that generates the existing Mental Model bundle
artifacts (OWL + SHACL JSON-LD), leaving the runtime (RDF4J, pyshacl,
owlrl, ShapesService) untouched. Includes construct mapping, phased
adoption plan, risks, and four side findings in the model layer.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EKdCjStHyxEkvu3eaT2Umx