### PR TITLE
docs: rewrite CODEBASE.md to match the current codebase

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,14 +1,20 @@
 # SemPKM Codebase Guide
 
-**Last updated:** 2026-03-12
+**Last updated:** 2026-09-03
+
+> **Keeping this file honest:** when a milestone adds a backend module, a top-level
+> directory, a Mental Model, or a Compose stack, update this file (and the
+> `.planning/codebase/` deep-dives) in the same change. Sanity-check the module
+> list against `ls backend/app` — this map intentionally avoids exact file/line
+> counts because those rot fastest.
 
 ## Overview
 
-SemPKM is an event-sourced RDF knowledge graph application with HTMX server-side rendering. It provides an IDE-style workspace for creating, browsing, and exploring structured knowledge through auto-generated forms, views, and graph visualizations.
+SemPKM is an event-sourced RDF knowledge graph application with htmx server-side rendering. It provides an IDE-style workspace for creating, browsing, and exploring structured knowledge through auto-generated forms, views, and graph visualizations.
 
-The system runs three Docker services: a **FastAPI backend** (Python, port 8001), an **nginx frontend** (static assets + reverse proxy, port 4000), and an **RDF4J triplestore** (SPARQL graph database). All writes flow through a single `POST /api/commands` endpoint into an immutable event store with current-state materialization. All reads query `urn:sempkm:current` via SPARQL and render Jinja2/htmx partials.
+The dev stack runs four Docker services: a **FastAPI backend** (Python, host port 8001), an **nginx frontend** (static assets + reverse proxy, host port 4000), an **RDF4J triplestore** (SPARQL graph database), and **Jaeger** (tracing). All writes flow through a single `POST /api/commands` endpoint into an immutable event store with current-state materialization. All reads query `urn:sempkm:current` via SPARQL and render Jinja2/htmx partials.
 
-Domain schemas are pluggable "Mental Models" (OWL ontology + SHACL shapes + view specs + seed data) installed at runtime.
+Domain schemas are pluggable **Mental Models** (OWL ontology + SHACL shapes + view specs + dashboards/workflows + seed data) installed at runtime from the bundled catalog or the remote marketplace. Beyond the web app, the repo ships **first-party platform apps** (`apps/` — sync integrations, RSS reader, media scheduler), a **browser extension** (`extension/`), and an **Expo mobile companion** (`mobile/`).
 
 ---
 
@@ -17,175 +23,152 @@ Domain schemas are pluggable "Mental Models" (OWL ontology + SHACL shapes + view
 ```
 SemPKM/
 ├── backend/                       # FastAPI Python backend
-│   ├── app/                       # Application package (24 modules)
-│   │   ├── admin/                 # Admin UI router (models, webhooks)
-│   │   ├── auth/                  # Passwordless auth (magic link, sessions, roles)
-│   │   ├── browser/               # IDE-style workspace router (main UI)
-│   │   ├── canvas/                # Spatial canvas (save/load, neighbor loading)
-│   │   ├── commands/              # Write command API (POST /api/commands)
-│   │   ├── db/                    # SQLAlchemy engine, session, base model
-│   │   ├── debug/                 # SPARQL console, command debug (dev only)
-│   │   ├── events/                # Event store (immutable graphs + materialization)
-│   │   ├── health/                # GET /api/health endpoint
-│   │   ├── indieauth/             # IndieAuth OAuth2 provider (PKCE)
-│   │   ├── inference/             # OWL 2 RL inference engine
-│   │   ├── lint/                  # Structured SHACL lint results API
-│   │   ├── models/                # Mental Model loader, registry
-│   │   ├── monitoring/            # PostHog error middleware
-│   │   ├── obsidian/              # Obsidian vault import (ZIP/scan/stream)
-│   │   ├── rdf/                   # IRI minting, JSON-LD, namespaces
-│   │   ├── services/              # Domain services (labels, shapes, etc.)
-│   │   ├── shell/                 # Admin shell router (dashboard pages)
-│   │   ├── sparql/                # SPARQL passthrough + graph scoping
-│   │   ├── templates/             # Jinja2 HTML templates (9 subdirs, ~67 files)
-│   │   ├── triplestore/           # RDF4J async HTTP client
-│   │   ├── validation/            # Background SHACL validation queue
-│   │   ├── vfs/                   # Virtual filesystem / WebDAV browser
-│   │   ├── views/                 # ViewSpec service + router
-│   │   ├── webid/                 # WebID profile management
-│   │   ├── config.py              # Pydantic BaseSettings (env vars)
-│   │   ├── dependencies.py        # FastAPI DI functions
-│   │   └── main.py                # App factory, lifespan, router registration
+│   ├── app/                       # Application package (~39 modules, see tables below)
 │   ├── migrations/                # Alembic SQL migrations
+│   ├── ontologies/                # Bundled base ontologies (gist)
 │   └── pyproject.toml             # Python dependencies
 ├── frontend/                      # Nginx static server + auth pages
-│   ├── static/css/                # 9 CSS files
-│   ├── static/js/                 # 17 JS modules
-│   ├── login.html                 # Auth page
-│   ├── setup.html                 # First-run setup
-│   ├── invite.html                # Invitation acceptance
+│   ├── static/css/                # CSS (theme tokens, workspace, per-view styles)
+│   ├── static/js/                 # Vanilla JS modules (window.SemPKM namespace)
+│   ├── login.html / setup.html / invite.html
 │   └── nginx.conf                 # Reverse proxy config
-├── models/                        # Mental Model bundles
-│   ├── basic-pkm/                 # Starter: Notes, Projects, Concepts, Persons
-│   └── ppv/                       # Personal Productivity Vault
+├── apps/                          # First-party platform apps (run by the app platform)
+│   │                              #   linear-sync, github-sync, jira-sync, monday-sync,
+│   │                              #   asana-sync, todoist-sync, google-calendar,
+│   │                              #   outlook-calendar, caldav-calendar,
+│   │                              #   rss-reader, media-scheduler, test-app
+├── extension/                     # WebExtension (Chrome + Firefox manifests):
+│   │                              #   sidebar, popup, content scripts, AI insights
+├── mobile/                        # Expo/React Native companion app (context reporting)
+├── models/                        # Mental Model bundles (see Mental Models below)
 ├── config/rdf4j/                  # RDF4J repository config (TTL)
-├── docs/guide/                    # User guide markdown
-├── e2e/                           # Playwright E2E tests
-│   ├── tests/                     # 17 test directories, ~46 spec files
-│   ├── fixtures/                  # Auth, seed data, test harness
-│   └── helpers/                   # Selectors, wait helpers, API client
-├── scripts/                       # Dev utilities (reset-instance.sh)
-├── .planning/                     # Planning docs + codebase analysis
-└── docker-compose.yml             # Full stack definition
+├── docs/guide/                    # User guide (50+ markdown chapters + HTML viewer)
+├── e2e/                           # Playwright E2E tests (tests/, fixtures/, helpers/, scripts/)
+├── scripts/                       # Dev utilities (reset-instance.sh, ...)
+├── .gsd/                          # Milestone/requirements tracking (PROJECT.md is the
+│                                  #   up-to-date architecture snapshot)
+├── .planning/codebase/            # Deep-dive architecture docs (see references below)
+├── docker-compose.yml             # Dev stack (see Docker Stacks below for the others)
+├── docker-compose.{test,test-ollama,demo,cloud,federation-test}.yml
+└── Caddyfile.cloud / Caddyfile.demo
 ```
 
 ---
 
 ## Backend Modules
 
+All modules live under `backend/app/`. Standard shape per module: `__init__.py`, `router.py`, `service.py`, `models.py`, `schemas.py` (subset as needed).
+
 ### Core
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `main` | App factory, lifespan startup, router registration | `main.py` | — |
-| `config` | Pydantic BaseSettings (env vars) | `config.py` | — |
-| `dependencies` | FastAPI DI functions (pull from app.state) | `dependencies.py` | — |
-| `db` | SQLAlchemy engine, async session, Base model | `engine.py`, `session.py` | ~60 |
-| `rdf` | IRI minting, JSON-LD parsing, namespace definitions | `iri.py`, `namespaces.py`, `jsonld.py` | ~190 |
-| `triplestore` | RDF4J async HTTP client + repository setup | `client.py`, `setup.py` | ~250 |
-| `sparql` | SPARQL passthrough router + `scope_to_current_graph()` | `client.py`, `router.py` | ~260 |
+| Module | Purpose |
+|--------|---------|
+| `main` | App factory, lifespan startup, router registration |
+| `config` | Pydantic BaseSettings (env vars) |
+| `dependencies` | FastAPI DI functions (pull from `app.state`) |
+| `db` | SQLAlchemy engine, async session, Base model |
+| `rdf` | IRI minting, JSON-LD parsing, namespace definitions |
+| `triplestore` | RDF4J async HTTP client + repository setup |
+| `sparql` | SPARQL passthrough router + `scope_to_current_graph()` |
+| `middleware` | ETag conditional GET for JSON APIs, request timing + admin report |
+| `security` | SSRF guard (`validate_outbound_url`), ZIP-bomb and tar validators |
 
 ### Commands and Events
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `commands` | Write command API (single `POST /api/commands` endpoint) | `router.py`, `dispatcher.py`, `schemas.py`, `handlers/` | ~750 |
-| `events` | Event store: immutable named graphs + current state materialization | `store.py`, `models.py` | ~860 |
+| Module | Purpose |
+|--------|---------|
+| `commands` | Write command API (single `POST /api/commands` endpoint): router, dispatcher, typed handlers |
+| `events` | Event store: immutable named graphs + current-state materialization, diff/undo support |
 
-### Services
+### Services and Knowledge
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `services` | Domain service singletons (labels, shapes, validation, webhooks, prefixes, icons, settings) | `labels.py`, `shapes.py`, `webhooks.py`, `settings.py` | ~2830 |
-| `models` | Mental Model loader, registry, manifest validation | `loader.py`, `registry.py`, `manifest.py` | ~1080 |
-| `views` | ViewSpec service + paginated SPARQL query execution | `service.py`, `router.py` | ~1780 |
-| `validation` | Background SHACL validation queue (asyncio worker) | `queue.py`, `report.py`, `router.py` | ~530 |
-| `inference` | OWL 2 RL forward-chaining inference engine | `service.py`, `entailments.py` | ~1360 |
-| `lint` | Structured SHACL lint results (paginated API, SSE stream) | `service.py`, `router.py`, `broadcast.py` | ~810 |
+| Module | Purpose |
+|--------|---------|
+| `services` | Domain service singletons: labels, shapes, webhooks, settings, search (Lucene), LLM connection, marketplace registry, ops log, email, icons, prefixes |
+| `models` | Mental Model loader, registry, manifest validation, bundled-model discovery |
+| `views` | ViewSpec service + paginated SPARQL query execution for all view renderers |
+| `validation` | Background SHACL validation queue (asyncio worker) |
+| `inference` | OWL 2 RL forward-chaining inference engine |
+| `lint` | Structured SHACL lint results (paginated API, SSE stream) |
+| `ontology` | Ontology viewer endpoints: TBox class graph/tree, ABox, RBox, user-created classes |
 
-### Auth and Identity
+### Auth, Identity, and Federation
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `auth` | Passwordless magic-link auth, sessions, roles (owner/member) | `service.py`, `models.py`, `dependencies.py`, `tokens.py` | ~1170 |
-| `indieauth` | IndieAuth OAuth2 provider (authorization code + PKCE) | `service.py`, `router.py`, `models.py`, `scopes.py` | ~860 |
-| `webid` | WebID profile (username, RSA keys, link management, public page) | `service.py`, `router.py`, `schemas.py` | ~490 |
+| Module | Purpose |
+|--------|---------|
+| `auth` | Passwordless magic-link auth, sessions, roles (owner/member), teams |
+| `indieauth` | IndieAuth OAuth2 provider (authorization code + PKCE) |
+| `webid` | WebID profile (username, Ed25519 keys, link management, public page) |
+| `federation` | Instance-to-instance federation: shared graphs, WebFinger, LDN inbox, RFC 9421 HTTP Message Signatures, RDF Patch sync (see [user guide ch. 51](docs/guide/51-federation.md)) |
 
 ### UI Routers
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `browser` | Main IDE-style workspace (nav tree, object tabs, forms, views, lint) | `router.py` | ~1570 |
-| `admin` | Admin portal (model management, webhooks, user management) | `router.py` | ~860 |
-| `shell` | Top-level navigation pages (dashboard, admin, health) | `router.py` | ~120 |
-| `debug` | SPARQL console, command executor (dev only) | `router.py` | ~30 |
+| Module | Purpose |
+|--------|---------|
+| `browser` | Main IDE-style workspace (nav tree, object tabs, forms, views, lint, explorer configs) |
+| `admin` | Admin portal (models + marketplace, webhooks, users, teams, API keys, applications, federation SPARQL-endpoint allowlist) |
+| `shell` | Top-level navigation pages, Docs & Tutorials hub (`GUIDE_SECTIONS` chapter registry) |
+| `debug` | SPARQL console, command executor (dev only) |
+| `api` | External API surface: well-known discovery, types/shapes/context-query endpoints |
 
 ### Features
 
-| Module | Purpose | Key Files | Lines |
-|--------|---------|-----------|-------|
-| `canvas` | Spatial canvas workspace (save/load, RDF neighbor loading) | `service.py`, `router.py`, `schemas.py` | ~510 |
-| `obsidian` | Obsidian vault import (ZIP upload, scan, streaming progress) | `scanner.py`, `executor.py`, `router.py`, `broadcast.py` | ~1890 |
-| `vfs` | Virtual filesystem / WebDAV (file browser, collections, resources) | `provider.py`, `router.py`, `collections.py`, `write.py`, `cache.py` | ~1230 |
-| `monitoring` | PostHog error middleware (captures 5xx exceptions) | `middleware.py`, `posthog.py` | ~170 |
-| `health` | Health check endpoint (`GET /api/health`) | `router.py` | ~30 |
+| Module | Purpose |
+|--------|---------|
+| `canvas` | Spatial canvas workspace (save/load, RDF neighbor loading) |
+| `dashboard` | DashboardSpec CRUD + GridStack dashboard builder/renderer |
+| `workflow` | WorkflowSpec CRUD + step-by-step workflow runner/builder |
+| `apps` | App platform: manifest validation, subprocess lifecycle manager, scheduler, proxy, tokens, admin routes |
+| `copilot` | AI Copilot chat — natural-language SPARQL generation and execution |
+| `obsidian` | Obsidian vault import (ZIP upload, scan, streaming progress) |
+| `notion` | Notion workspace ZIP import (scanner, models, router) |
+| `rdf_import` | Generic RDF data import: format detection, parsing, subject extraction |
+| `vfs` | Virtual filesystem / WebDAV (file browser, collections, resources) |
+| `context` | Context awareness: user location/activity/time tracking (feeds mobile + overlay) |
+| `persona` | Workspace persona management (named layout/sidebar/explorer configurations) |
+| `favorites` | Starred objects (SQLAlchemy model) |
+| `task_templates` | RDF-backed reusable task template CRUD |
+| `monitoring` | PostHog error middleware (captures 5xx exceptions) |
+| `health` | Health check endpoint (`GET /api/health`) |
 
 ---
 
 ## Frontend Assets
 
-### JavaScript (17 files)
+Vanilla JS modules under `frontend/static/js/` (IIFE, `window.SemPKM` namespace), bundled with esbuild — no SPA framework. Grouped by area:
 
-| File | Purpose | Lines |
-|------|---------|-------|
-| `app.js` | Application bootstrap and event wiring | ~450 |
-| `workspace.js` | Split pane management, object tab logic, right pane sections | ~2120 |
-| `workspace-layout.js` | Dockview workspace layout manager | ~550 |
-| `canvas.js` | Spatial canvas interactions (Cytoscape.js graph exploration) | ~940 |
-| `graph.js` | Graph visualization (Cytoscape.js + fcose/dagre layouts) | ~690 |
-| `vfs-browser.js` | VFS file browser panel | ~650 |
-| `editor.js` | Object editing, command dispatch via fetch | ~260 |
-| `auth.js` | Session management, auth state, login flow | ~340 |
-| `tutorials.js` | Driver.js guided tour overlays | ~270 |
-| `column-prefs.js` | Table column visibility persistence (localStorage) | ~190 |
-| `named-layouts.js` | Named layout save/restore | ~180 |
-| `sidebar.js` | Sidebar toggle | ~140 |
-| `markdown-render.js` | Markdown rendering (marked.js + DOMPurify) | ~130 |
-| `theme.js` | Dark/light mode toggle | ~130 |
-| `posthog.js` | PostHog analytics SDK loader | ~120 |
-| `cleanup.js` | Resource cleanup utilities | ~60 |
-| `settings.js` | Settings page interactions | ~50 |
+| Area | Files |
+|------|-------|
+| Bootstrap & shared | `app.js`, `api-fetch.js`, `auth.js`, `cleanup.js`, `sempkm-shims.js`, `dropdown-dismiss.js`, `posthog.js`, `theme.js` |
+| Workspace shell | `workspace.js`, `workspace-layout.js` (Dockview, deep links, closed-tab recovery), `sidebar.js`, `named-layouts.js`, `explorer-config.js`, `context-indicator.js`, `tutorials.js` |
+| Editing | `editor.js` (command dispatch), `markdown-render.js` (marked.js + DOMPurify), `recurrence-editor.js`, `column-prefs.js` |
+| View renderers | `graph.js` (Cytoscape), `kanban.js`, `calendar.js`, `okr.js`, `bmc.js`, `quadrant.js`, `decision-matrix.js` |
+| Feature panels | `canvas.js` (spatial canvas), `ontology-graph.js` (TBox graph), `federation.js` (collab/inbox panels), `copilot.js`, `sparql-console.js`, `vfs-browser.js`, `settings.js` |
 
-### CSS (9 files)
-
-| File | Purpose |
-|------|---------|
-| `style.css` | Base application styles |
-| `workspace.css` | Workspace layout, object editor, panels |
-| `forms.css` | SHACL-driven form styles |
-| `views.css` | Table, cards, graph view styles (incl. 3D flip cards) |
-| `theme.css` | CSS custom properties (light/dark mode tokens) |
-| `settings.css` | Settings page styles |
-| `dockview-sempkm-bridge.css` | Dockview theme variable bridge |
-| `import.css` | Obsidian import UI styles |
-| `vfs-browser.css` | VFS file browser panel styles |
+CSS under `frontend/static/css/` follows the same split: base (`style.css`, `theme.css` — light/dark tokens), workspace (`workspace.css`, `dockview-sempkm-bridge.css`, `forms.css`, `views.css`), and one file per feature panel/renderer (`federation.css`, `copilot.css`, `explorer-config.css`, `okr.css`, `bmc.css`, `quadrant.css`, `decision-matrix.css`, `context-indicator.css`, `import.css`, `vfs-browser.css`, `settings.css`).
 
 ---
 
 ## Templates
 
+Jinja2 templates under `backend/app/templates/` (rendered full-page or as htmx fragments via `jinja2-fragments`):
+
 ```
 backend/app/templates/
-├── base.html                  # Base layout (htmx, CDN scripts, sidebar)
-├── admin/       (7)           # Admin portal (models, webhooks, users)
-├── browser/     (39)          # Workspace, nav tree, object tab, views, lint, canvas
-├── components/  (2)           # Shared partials (_sidebar.html, _tabs.html)
-├── debug/       (3)           # SPARQL console, command executor
-├── errors/      (1)           # Error pages (403)
-├── forms/       (3)           # SHACL-driven form partials
-├── indieauth/   (2)           # IndieAuth authorization consent UI
-├── obsidian/    (10)          # Obsidian import wizard UI
-└── webid/       (1)           # WebID public profile page
+├── base.html / base_embed.html   # Base layouts (htmx, CDN scripts, sidebar)
+├── admin/        # Admin portal (models, marketplace, webhooks, users, apps, federation endpoints)
+├── browser/      # Workspace: nav tree, object tabs, views, lint, canvas, dashboards,
+│                 #   workflows, ontology viewer, federation panels (largest group)
+├── components/   # Shared partials (_sidebar.html, _tabs.html)
+├── debug/        # SPARQL console, command executor
+├── errors/       # Error pages
+├── forms/        # SHACL-driven form partials
+├── importer/     # Generic import UI shared pieces
+├── indieauth/    # IndieAuth authorization consent UI
+├── notion/       # Notion import wizard
+├── obsidian/     # Obsidian import wizard
+├── rdf_import/   # RDF import wizard
+└── webid/        # WebID public profile page
 ```
 
 ---
@@ -193,72 +176,62 @@ backend/app/templates/
 ## Mental Models
 
 Mental Models are pluggable domain schemas containing:
-- `manifest.yaml` -- metadata (modelId, version, namespace, entrypoints, icons)
-- `ontology/` -- OWL ontology (JSON-LD)
-- `shapes/` -- SHACL shapes for auto-generated forms (JSON-LD)
-- `views/` -- ViewSpec definitions for table/cards/graph renderers (JSON-LD)
-- `seed/` -- Seed data objects (JSON-LD)
+- `manifest.yaml` — metadata (modelId, version, namespace, entrypoints, icons)
+- `ontology/` — OWL ontology (JSON-LD)
+- `shapes/` — SHACL shapes for auto-generated forms (JSON-LD)
+- `views/` — ViewSpec definitions for the view renderers (JSON-LD)
+- `seed/` — Seed data objects (JSON-LD)
+- optionally dashboards, workflows, and rules
 
-**Installed models:**
+**Bundled models** (`models/`, mounted read-only at `/app/models/`):
 
-| Model | Domain | Types |
-|-------|--------|-------|
-| `basic-pkm` | Personal Knowledge Management | Note, Project, Concept, Person |
-| `ppv` | Personal Productivity Vault | Extended productivity types + rules |
+| Model | Domain |
+|-------|--------|
+| `basic-pkm` | Starter PKM: Notes, Projects, Concepts, Persons |
+| `zettelkasten` | Zettelkasten note-taking (fleeting/literature/permanent notes) |
+| `research` | Research workflow (papers, claims, research questions) |
+| `crm` | Contacts, companies, deals, interactions |
+| `business-planning` | OKRs, Business Model Canvas, decision matrices |
+| `ppv` | Pillars–Pipelines–Vaults personal productivity |
+| `rss-feeds` | Types backing the RSS Reader app |
+| `media-scheduler` | Types backing the Media Scheduler app |
 
-Models are mounted read-only into the container at `/app/models/` and installed via the admin UI or `ModelService.install_model()`. Each model's artifacts are stored in named graphs: `urn:sempkm:model:{id}:ontology`, `:shapes`, `:views`, `:seed`.
+Models install via the admin UI (bundled catalog card grid) or from the **remote marketplace** (`MarketplaceRegistryService`: JSON registry + SHA-256-verified `.tar.gz` archives, version checking, downloads to `/app/data/models/`). Each model's artifacts land in named graphs: `urn:sempkm:model:{id}:ontology`, `:shapes`, `:views`, `:seed`.
 
 ---
 
 ## E2E Tests
 
-82 spec files across 28 directories (80 functional + 2 screenshot capture).
+Playwright specs under `e2e/tests/`, grouped by numbered directory (55+ directories; run `ls e2e/tests` for the current list):
 
-| Directory | Test Area | Specs |
-|-----------|-----------|-------|
-| `00-setup/` | Setup wizard, magic link auth, health check | 3 |
-| `01-objects/` | Object CRUD, deletion, edges, edge.patch, markdown, tooltips | 11 |
-| `02-views/` | Table, cards, graph, pagination, column prefs | 7 |
-| `03-navigation/` | Nav tree, tabs, keyboard shortcuts, sidebar reorder, layouts | 7 |
-| `04-validation/` | Lint API, validation lifecycle, lint panel | 3 |
-| `05-admin/` | Admin portal, models, webhooks, SPARQL, debug pages | 9 |
-| `06-settings/` | Settings, dark mode, events, LLM config, docs, misc endpoints | 9 |
-| `07-multi-user/` | Member permissions, sessions, invite flow | 3 |
-| `08-search/` | Full-text search, fuzzy toggle | 2 |
-| `09-inference/` | OWL inference engine | 1 |
-| `10-lint-dashboard/` | Lint dashboard | 1 |
-| `11-helptext/` | Help text / tooltips | 1 |
-| `12-bug-fixes/` | Regression tests | 1 |
-| `13-v24-coverage/` | v2.4 coverage, VFS browser, VFS mountspec | 4 |
-| `14-obsidian-import/` | Obsidian vault import | 3 |
-| `15-webid/` | WebID profile | 1 |
-| `16-indieauth/` | IndieAuth OAuth2 flow | 1 |
-| `17-spatial-canvas/` | Canvas UI + API (sessions, subgraph, wiki-links) | 2 |
-| `18-federation/` | Federation UI partials, federation sync | 2 |
-| `19-explorer-modes/` | Explorer mode switching (by-type, hierarchy, by-tag) | 1 |
-| `20-favorites/` | Favorites star toggle and sidebar | 1 |
-| `20-tags/` | Tag pills and tag explorer | 1 |
-| `20-vfs-explorer/` | VFS explorer mount mode | 1 |
-| `21-comments/` | Comments thread, soft-delete | 1 |
-| `22-ontology/` | Ontology viewer (TBox, ABox, RBox) | 1 |
-| `23-class-creation/` | User-created classes | 1 |
-| `99-rate-limiting/` | Auth rate limiting (429) | 1 |
-| `screenshots/` | Marketing + guide screenshot capture | 2 |
-| *(root)* | VFS WebDAV | 1 |
+| Range | Test Areas |
+|-------|-----------|
+| `00`–`08` | Setup/auth, object CRUD + edges, view renderers, navigation/tabs/shortcuts, validation/lint, admin portal, settings, multi-user, search |
+| `09`–`17` | Inference, lint dashboard, helptext, regressions, VFS, Obsidian import, WebID, IndieAuth, spatial canvas |
+| `18`–`23` | Federation (UI + two-instance sync), explorer modes, favorites/tags/VFS explorer, comments, ontology viewer, class creation |
+| `24`–`30` | Tag hierarchy, browser extension, ops log, mental models + marketplace, event log, body diff, personas, API surface, app platform |
+| `31`–`47` | Sync apps (Linear, GitHub, Jira, Monday, Asana, Todoist, Google/Outlook/CalDAV calendars), RSS reader, business planning, dashboard blocks, copilot, PPV |
+| `50`–`99` | Hosted demo, browser history, media scheduler, Notion import, rate limiting |
+| `screenshots/` | Marketing + guide screenshot capture |
 
-**Run:** `cd e2e && npx playwright test --project=chromium` (sequential, 1 worker)
+**Run:** `cd e2e && npx playwright test --project=chromium` against the test stack (`docker compose -f docker-compose.test.yml up -d --build`, sequential, 1 worker). Federation specs need the federation stack (`--project=federation`).
 
 ---
 
-## Docker Services
+## Docker Stacks
 
-| Service | Image | Internal Port | Host Port | Purpose |
-|---------|-------|---------------|-----------|---------|
-| `triplestore` | `eclipse/rdf4j-workbench:5.0.1` | 8080 | (internal) | RDF4J SPARQL graph database |
-| `api` | Custom (`./backend` Dockerfile) | 8000 | 8001 | FastAPI backend (uvicorn, hot-reload) |
-| `frontend` | `nginx:stable-alpine` | 80 | 4000 | Static assets + reverse proxy to API |
+Dev stack (`docker-compose.yml`):
 
-**Key volumes:** `rdf4j_data` (triplestore persistence), `sempkm_data` (SQLite + secrets), `lucene_index` (full-text search)
+| Service | Image | Host Port | Purpose |
+|---------|-------|-----------|---------|
+| `triplestore` | `eclipse/rdf4j-workbench:5.0.1` | (internal) | RDF4J SPARQL graph database |
+| `api` | Custom (`./backend` Dockerfile) | 8001 | FastAPI backend (uvicorn, hot-reload) |
+| `frontend` | `nginx:stable-alpine` | 4000 | Static assets + reverse proxy to API |
+| `jaeger` | `jaegertracing/all-in-one` | 16686 (UI), 4318 (OTLP) | Distributed tracing |
+
+**Key volumes:** `rdf4j_data` (triplestore persistence), `sempkm_data` (SQLite + secrets), plus hot-reload bind mounts (see [CLAUDE.md](CLAUDE.md) — Python, templates, CSS, JS, and migrations reload without a rebuild).
+
+Additional self-contained stacks (ports and purposes in the [README](README.md#docker-stacks)): `docker-compose.test.yml` (E2E target with ~10 mock integration APIs; `test-ollama` variant swaps the mock LLM for real Ollama), `demo` (read-only public demo), `cloud` (Caddy TLS overlay), and `federation-test` (two full instances side by side).
 
 ---
 
@@ -273,13 +246,13 @@ Browser JS (editor.js)
 nginx (port 4000) --> proxy_pass --> FastAPI (port 8000)
   |
   v
-commands/router.py --> dispatcher.py --> handlers/object_create.py
+commands/router.py --> dispatcher.py --> handlers/{command}.py
   |  Returns Operation (data_triples + materialize_inserts)
   v
 events/store.py EventStore.commit()
   |  1. Begin RDF4J transaction
   |  2. Insert event triples into urn:sempkm:event:{uuid}
-  |  3. Materialize into urn:sempkm:current
+  |  3. Materialize into urn:sempkm:current (or a target graph, e.g. a shared graph)
   |  4. Commit transaction (atomic)
   v
 Async: ValidationQueue.enqueue() + WebhookService.dispatch()
@@ -298,7 +271,7 @@ nginx --> FastAPI browser/router.py
 LabelService.resolve_batch() (TTL-cached)
   |
   v
-Jinja2Blocks renders template (full page or htmx partial)
+Jinja2 renders template (full page or htmx partial)
   |
   v
 HTML response (hx-swap into DOM)
@@ -308,15 +281,16 @@ HTML response (hx-swap into DOM)
 
 ## Key Conventions
 
-- **Single write path:** All data mutations go through `POST /api/commands` -- never direct SPARQL UPDATE
-- **Event sourcing:** Every write creates an immutable named graph event; current state is materialized
+- **Single write path:** All data mutations go through `POST /api/commands` — never direct SPARQL UPDATE
+- **Event sourcing:** Every write creates an immutable named graph event; current state is materialized. The event log UI supports per-event diff and undo
 - **Module structure:** Each module follows `__init__.py`, `router.py`, `service.py`, `models.py`, `schemas.py`
 - **Service injection:** Services are singletons on `app.state.*`, injected via FastAPI `Depends()` from `dependencies.py`
 - **htmx partials:** Routes serve both full pages and htmx fragments using `jinja2-fragments` block rendering
-- **Graph scoping:** All SPARQL reads use `scope_to_current_graph()` to prevent event graph data leaking
-- **Named graphs:** `urn:sempkm:current` (state), `urn:sempkm:event:{uuid}` (events), `urn:sempkm:model:{id}:{artifact}` (models), `urn:sempkm:inferred` (inference)
+- **Graph scoping:** All SPARQL reads use `scope_to_current_graph()` to prevent event graph data leaking; shared graph membership adds extra `FROM` clauses
+- **Named graphs:** `urn:sempkm:current` (state), `urn:sempkm:event:{uuid}` (events), `urn:sempkm:model:{id}:{artifact}` (models), `urn:sempkm:inferred` (inference), `urn:sempkm:shared:{uuid}` (federation shared graphs), `urn:sempkm:inbox:{uuid}` (LDN notifications)
 - **Label precedence:** `dcterms:title > rdfs:label > skos:prefLabel > schema:name > foaf:name > QName`
 - **Naming:** Python `snake_case`, CSS/JS `kebab-case`, classes `PascalCase`, constants `UPPER_SNAKE_CASE`
+- **Outbound HTTP:** Anything fetching a user-supplied URL must go through `security/ssrf.py::validate_outbound_url()`
 
 ### Where to Add New Code
 
@@ -324,6 +298,8 @@ HTML response (hx-swap into DOM)
 - **New service:** `services/{name}.py` + instantiate in `main.py` lifespan + DI in `dependencies.py`
 - **New router/feature:** `{feature}/router.py` + `__init__.py` + register in `main.py` + templates in `templates/{feature}/`
 - **New Mental Model:** `models/{id}/manifest.yaml` + `ontology/`, `shapes/`, `views/`, `seed/`
+- **New platform app:** `apps/{id}/manifest.yaml` + entrypoint; install via Admin > Applications
+- **New user guide chapter:** the chapter list lives in THREE places — `docs/guide/README.md`, `docs/guide/index.html`, and `GUIDE_SECTIONS` in `shell/router.py` (see `.gsd/KNOWLEDGE.md`)
 
 See `.planning/codebase/STRUCTURE.md` for full details.
 
@@ -333,6 +309,7 @@ See `.planning/codebase/STRUCTURE.md` for full details.
 
 | Document | Contents |
 |----------|----------|
+| [`.gsd/PROJECT.md`](.gsd/PROJECT.md) | Current architecture snapshot, updated per milestone (freshest source) |
 | [`.planning/codebase/ARCHITECTURE.md`](.planning/codebase/ARCHITECTURE.md) | Layer details, data flows, key abstractions, entry points |
 | [`.planning/codebase/STACK.md`](.planning/codebase/STACK.md) | All dependencies and versions (Python, CDN, Docker) |
 | [`.planning/codebase/CONVENTIONS.md`](.planning/codebase/CONVENTIONS.md) | Code style, naming, error handling, template patterns |


### PR DESCRIPTION
Fixes #27.

Bring the repo map (last updated 2026-03-12) up to date: document all 39 backend modules (federation, copilot, dashboard, workflow, apps platform, ontology, persona, security, middleware, notion, rdf_import, context, favorites, task_templates, api), the full frontend JS/CSS set grouped by area, 12 template subdirectories, all 8 bundled Mental Models plus the marketplace install path, the current E2E suite (126 specs, 55 dirs, summarized by range), the 4-service dev stack including Jaeger, and the additional Compose stacks. Add apps/, extension/, mobile/, and .gsd/ to the directory layout, correct WebID keys from RSA to Ed25519, extend the named-graph and conventions lists (shared graphs, inbox, SSRF guard, three-way guide chapter registry), and drop exact file/line counts in favor of purpose descriptions.

Add a maintenance note at the top so the map is updated alongside milestones instead of silently rotting, and link .gsd/PROJECT.md as the freshest architecture snapshot.


Claude-Session: https://claude.ai/code/session_01L4tViHEp7j42VDSnaB66E4