### PR TITLE
docs: enlarge hero screenshot crop and brighten the dot grid

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -298,7 +298,7 @@ section {
 .hero-dotgrid {
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(rgba(152, 152, 176, 0.12) 1px, transparent 1px);
+  background-image: radial-gradient(rgba(152, 152, 176, 0.22) 1px, transparent 1px);
   background-size: 28px 28px;
   -webkit-mask-image: linear-gradient(to bottom, black 40%, transparent 100%);
   mask-image: linear-gradient(to bottom, black 40%, transparent 100%);
@@ -308,8 +308,8 @@ section {
 .hero-shot {
   position: relative;
   max-width: 1240px;
-  margin: 3.5rem auto -6rem;
-  height: 460px;
+  margin: 2.25rem auto -6rem;
+  height: 580px;
   overflow: hidden;
 }
 
@@ -385,8 +385,8 @@ section {
 
 @media (max-width: 768px) {
   .hero-shot {
-    height: 260px;
-    margin-top: 2.5rem;
+    height: 300px;
+    margin-top: 2rem;
   }
 }
 


### PR DESCRIPTION
Final polish pass on the new landing-page hero (rest of the redesign already landed via #32):

- **Screenshot raised and extended** — the gap between the CTAs and the browser frame tightens from 3.5rem to 2.25rem, and the crop window grows from 460px to 580px (260px → 300px on mobile), so the reclaimed vertical space shows more of the workspace: the full object panel through its Notes/Created rows plus the relations sidebar, before the fade.
- **Dot grid more prominent** — backdrop dot alpha bumped from 0.12 to 0.22 so it reads clearly behind the headline without competing with the text.

Verified with headless Chromium at 1440px and 390px widths (reduced-motion path included). Two CSS values only (`.hero-shot` height/margin, `.hero-dotgrid` alpha) — trivial to nudge further if the balance needs adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4tViHEp7j42VDSnaB66E4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4tViHEp7j42VDSnaB66E4)_