### PR TITLE
docs: point guide nav at guide chapters instead of dead landing anchors

### DIFF
--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -398,11 +398,12 @@ a:hover {
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links">
-      <li><a href="../index.html#features">Features</a></li>
-      <li><a href="../index.html#screenshots">Screenshots</a></li>
-      <li><a href="../index.html#deploy">Deploy</a></li>
+      <li><a href="#03-installation-and-setup">Getting Started</a></li>
+      <li><a href="#04-workspace-interface">Workspace</a></li>
+      <li><a href="#09-understanding-mental-models">Mental Models</a></li>
+      <li><a href="#20-production-deployment">Deploy</a></li>
       <li><a href="index.html" class="nav-active">User Guide</a></li>
-      <li><a href="../index.html#signup" class="nav-cta">Get Started</a></li>
+      <li><a href="https://demo.sempkm.app" class="nav-cta">Try Demo</a></li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
The guide's top nav linked to ../index.html#screenshots, #deploy, and #signup — anchors that don't exist on the landing page, so the links just dumped visitors at the top of it. Using the viewer's new deep links, the nav now goes to sections within the guide: Getting Started (ch. 3), Workspace (ch. 4), Mental Models (ch. 9), and Deploy (ch. 20), and the CTA points at the live demo as Try Demo, matching the marketing pages.


Claude-Session: https://claude.ai/code/session_01L4tViHEp7j42VDSnaB66E4